### PR TITLE
fixes GHA 

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,10 +16,10 @@ jobs:
           python-version: 3.9
       - name: Install dependencies
         run: |
+          sudo mkdir -p /usr/local/var/hio/test
           sudo mkdir -p /usr/local/var/hio/logs
           sudo mkdir -p /usr/local/var/hio/wirelogs
-          sudo chown -R $USER /usr/local/var/hio/logs
-          sudo chown -R $USER /usr/local/var/hio/wirelogs
+          sudo chown -R $USER /usr/local/var/hio
           python -m pip install --upgrade pip
           pip install pytest
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi

--- a/tests/base/test_doist.py
+++ b/tests/base/test_doist.py
@@ -802,7 +802,7 @@ def test_doist_dos():
 
     assert doer0 is not doer1
 
-    doer2 = doing.doizeExDo
+    doer2 = doing.doify(doing.doizeExDo, tock=0, states=None)
     assert inspect.isgeneratorfunction(doer2)
     assert doer2.opts["states"] == None
     doer2.opts["states"] = []


### PR DESCRIPTION
There is a previous commit that states not to use doize on methods yet both `test_doing` and `test_doist` use `doing.doizeExDo` without making a copy of it. This is causing the tests to fail when run in parallel - I modified one test to use doing.doify instead, which does make a copy.