### PR TITLE
Fix http.clienting.Client to successfully redirect if connector does not have a context attribute.

### DIFF
--- a/src/hio/core/http/clienting.py
+++ b/src/hio/core/http/clienting.py
@@ -1009,7 +1009,7 @@ class Client():
                                       "host '{0}'".format(location))
                 self.connector.close()
                 if secured:
-                    context = getattr(self.connector, 'context')
+                    context = getattr(self.connector, 'context') if hasattr(self.connector, 'context') else None
                     connector = tcp.ClientTls(tymth=self.connector.tymth,
                                            ha=(hostname, port),
                                            bufsize=self.connector.bs,


### PR DESCRIPTION
Error occurs when redirecting SSL URLs because  the Client.connector does not have a "context" attribute.  The fix of setting it to None works because the newly create ClientTls creates a new context if needed.

Signed-off-by: pfeairheller <pfeairheller@gmail.com>