### PR TITLE
Add "exists" method to Filer

### DIFF
--- a/src/hio/base/filing.py
+++ b/src/hio/base/filing.py
@@ -355,8 +355,66 @@ class Filer():
 
             os.chmod(path, perm)  # set dir/file permissions
 
-        return (path, file)
+        return path, file
 
+    def exists(self, name="", base="", headDirPath=None, clean=False, filed=False, fext=None):
+        """
+        Check if (path. file) exists for a given set of parameters for remake.  Temp is not allowed.
+
+        Parameters:
+            name (str): unique name alias portion of path
+            base (str): optional base inserted before name in path
+
+            headDirPath (str): optional head directory pathname of main database
+
+            clean (bool): True means make path for cleaned version and  remove
+                          old directory or file at clean path if any.
+                          False means make path normally (not clean)
+
+            filed (bool): True means .path is file path not directory path
+                          False means .path is directiory path not file path
+            fext (str): File extension when .filed
+
+        Returns:
+            bool: True means path or alt path exists, false means neither exists
+
+        """
+
+        # use class defaults here so can use makePath for other dirs and files
+        if headDirPath is None:
+            headDirPath = self.HeadDirPath
+
+        if fext is None:
+            fext = self.Fext
+
+        tailDirPath = self.CleanTailDirPath if clean else self.TailDirPath
+        altTailDirPath = self.AltCleanTailDirPath if clean else self.AltTailDirPath
+
+        if filed:
+            root, ext = os.path.splitext(name)
+            if not ext:
+                name = f"{name}.{fext}"
+
+        path = os.path.abspath(
+            os.path.expanduser(
+                os.path.join(headDirPath,
+                             tailDirPath,
+                             base,
+                             name)))
+
+        # Check non-alt, if exists return True
+        if os.path.exists(path):
+            return True
+
+        # Now we must check the alt path to see if that exists.
+        headDirPath = self.AltHeadDirPath
+        path = os.path.abspath(
+            os.path.expanduser(
+                os.path.join(headDirPath,
+                             altTailDirPath,
+                             base,
+                             name)))
+        return os.path.exists(path)
 
     def close(self, clear=False):
         """

--- a/tests/base/test_filing.py
+++ b/tests/base/test_filing.py
@@ -3,6 +3,8 @@
 tests.help.test_filing module
 
 """
+import shutil
+
 import pytest
 import os
 
@@ -15,6 +17,9 @@ def test_filing():
     Test Filer class
     """
     dirpath = '/usr/local/var/hio/test'
+    if os.path.exists(dirpath):
+        shutil.rmtree(dirpath)
+
     filer = filing.Filer(name="test", reopen=False)  # defaults
     assert filer.exists(name="test") is False
 
@@ -54,6 +59,9 @@ def test_filing():
 
     # Test with clean
     dirpath = '/usr/local/var/hio/clean/test'
+    if os.path.exists(dirpath):
+        shutil.rmtree(dirpath)
+
     filer = filing.Filer(name="test", clean="true", reopen=False)  # defaults
     assert filer.exists(name="test", clean="true") is False
 
@@ -94,6 +102,9 @@ def test_filing():
 
     # test with alt
     dirpath = '/Users/samuel/.hio/test'
+    if os.path.exists(dirpath):
+        shutil.rmtree(dirpath)
+
     # headDirPath that is not permitted to force using AltPath
     filer = filing.Filer(name="test", headDirPath="/root/hio", reopen=False)
     assert filer.exists(name="test", headDirPath="/root/hio") is False
@@ -134,6 +145,9 @@ def test_filing():
 
     # Test Filer with file not dir
     filepath = '/usr/local/var/hio/conf/test.text'
+    if os.path.exists(filepath):
+        os.remove(filepath)
+
     assert os.path.exists(filepath) is False
     filer = filing.Filer(name="test", base="conf", filed=True, reopen=False)
     assert filer.exists(name="test", base="conf", filed=True) is False
@@ -186,6 +200,9 @@ def test_filing():
 
     # Test Filer with file not dir and with Alt path
     filepath = '/Users/samuel/.hio/conf/test.text'
+    if os.path.exists(filepath):
+        os.remove(filepath)
+
     # force altPath by using headDirPath of "/root/hio" which is not permitted
     filer = filing.Filer(name="test", base="conf", headDirPath="/root/hio", filed=True, reopen=False)
     assert filer.exists(name="test", base="conf", headDirPath="/root/hio", filed=True) is False

--- a/tests/base/test_filing.py
+++ b/tests/base/test_filing.py
@@ -15,7 +15,11 @@ def test_filing():
     Test Filer class
     """
     dirpath = '/usr/local/var/hio/test'
+    filer = filing.Filer(name="test", reopen=False)  # defaults
+    assert filer.exists(name="test") is False
+
     filer = filing.Filer(name="test")  # defaults
+    assert filer.exists(name="test") is True
     assert filer.path.endswith("hio/test")
     assert filer.opened
     assert os.path.exists(filer.path)
@@ -50,7 +54,12 @@ def test_filing():
 
     # Test with clean
     dirpath = '/usr/local/var/hio/clean/test'
+    filer = filing.Filer(name="test", clean="true", reopen=False)  # defaults
+    assert filer.exists(name="test", clean="true") is False
+
     filer = filing.Filer(name="test", clean="true")  # defaults
+    assert filer.exists(name="test", clean="true") is True
+
     assert filer.path.endswith("hio/clean/test")
     assert filer.opened
     assert os.path.exists(filer.path)
@@ -86,7 +95,11 @@ def test_filing():
     # test with alt
     dirpath = '/Users/samuel/.hio/test'
     # headDirPath that is not permitted to force using AltPath
+    filer = filing.Filer(name="test", headDirPath="/root/hio", reopen=False)
+    assert filer.exists(name="test", headDirPath="/root/hio") is False
+
     filer = filing.Filer(name="test", headDirPath="/root/hio")
+    assert filer.exists(name="test", headDirPath="/root/hio") is True
     assert filer.path.endswith(".hio/test")
     assert filer.opened
     assert os.path.exists(filer.path)
@@ -121,8 +134,12 @@ def test_filing():
 
     # Test Filer with file not dir
     filepath = '/usr/local/var/hio/conf/test.text'
+    assert os.path.exists(filepath) is False
+    filer = filing.Filer(name="test", base="conf", filed=True, reopen=False)
+    assert filer.exists(name="test", base="conf", filed=True) is False
 
     filer = filing.Filer(name="test", base="conf", filed=True)
+    assert filer.exists(name="test", base="conf", filed=True) is True
     assert filer.path.endswith("hio/conf/test.text")
     assert filer.opened
     assert os.path.exists(filer.path)
@@ -170,7 +187,11 @@ def test_filing():
     # Test Filer with file not dir and with Alt path
     filepath = '/Users/samuel/.hio/conf/test.text'
     # force altPath by using headDirPath of "/root/hio" which is not permitted
+    filer = filing.Filer(name="test", base="conf", headDirPath="/root/hio", filed=True, reopen=False)
+    assert filer.exists(name="test", base="conf", headDirPath="/root/hio", filed=True) is False
+
     filer = filing.Filer(name="test", base="conf", headDirPath="/root/hio", filed=True)
+    assert filer.exists(name="test", base="conf", headDirPath="/root/hio", filed=True) is True
     assert filer.path.endswith(".hio/conf/test.text")
     assert filer.opened
     assert os.path.exists(filer.path)


### PR DESCRIPTION
The PR adds an `exists` method to Filer that will check for existence of directory or file before "reopen" creates it.