### PR TITLE
A few fixes for issues discovered when using large request bodies:

### DIFF
--- a/src/hio/core/tcp/serving.py
+++ b/src/hio/core/tcp/serving.py
@@ -283,7 +283,7 @@ class Server(Acceptor):
                               wl=self.wl,
                               timeout=self.tymeout)
             if ca in self.ixes and self.ixes[ca] is not remoter:
-                self.shutdownIx[ca]
+                self.shutdownIx(ca)
             self.ixes[ca] = remoter
 
 


### PR DESCRIPTION
- TCP Server fix call to "shutdownIx" to be a func call
- HTTP Responder, allow for a clean exit after timeout
- Handle chunk encoding if WSGI handler already sets "chunked" in transfer-encoding header
- Remove body from default info level log of each request.  For large bodies, this is too much.