### PR TITLE
adds quote of path to adhere to PEP3333

### DIFF
--- a/src/hio/core/http/serving.py
+++ b/src/hio/core/http/serving.py
@@ -12,7 +12,7 @@ import copy
 import datetime
 import mimetypes
 
-from urllib.parse import urlsplit, unquote
+from urllib.parse import urlsplit, unquote, quote
 from contextlib import contextmanager
 
 from ... import help
@@ -725,7 +725,7 @@ class Server():
         environ['SERVER_PORT'] = str(self.servant.eha[1])  # 8888
         environ['SERVER_PROTOCOL'] = "HTTP/{0}.{1}".format(*requestant.version)  # used by request http/1.1
         environ['SCRIPT_NAME'] = u''
-        environ['PATH_INFO'] = requestant.path        # /hello?name=john
+        environ['PATH_INFO'] = quote(requestant.path)        # /hello?name=john
 
         # Optional CGI variables
         environ['QUERY_STRING'] = requestant.query        # name=john


### PR DESCRIPTION
There is a potential for requests using UTF-8 characters within the request path to cause a crash with WSGI.

        # PEP 3333 specifies that the PATH_INFO variable is always
        # "bytes tunneled as latin-1" and must be encoded back.
        #
        # NOTE(kgriffs): The decoded path may contain UTF-8 characters.
        # But according to the WSGI spec, no strings can contain chars
        # outside ISO-8859-1. Therefore, to reconcile the URI
        # encoding standard that allows UTF-8 with the WSGI spec
        # that does not, WSGI servers tunnel the string via
        # ISO-8859-1, e.g.:
        #
        #   tunnelled_path = path.encode('utf-8').decode('iso-8859-1')
        
        # perf(vytas): Only decode the tunnelled path in case it is not ASCII.
        #   For ASCII-strings, the below decoding chain is a no-op.
        # If not isascii(path):
            path = path.encode('iso-8859-1').decode('utf-8', 'replace')
    
Is the relevant PEP, thanks @pfeairheller 
