### PR TITLE
Windows Compatibility

### DIFF
--- a/src/hio/base/filing.py
+++ b/src/hio/base/filing.py
@@ -113,13 +113,16 @@ class Filer(hioing.Mixin):
         stat.S_IWUSR Owner has write permission.
         stat.S_IXUSR Owner has execute permission.
     """
-    HeadDirPath = "/usr/local/var"  # default in /usr/local/var
+    HeadDirPath = os.path.join(os.path.sep, 'usr', 'local', 'var')  # default in /usr/local/var
     TailDirPath = "hio"
-    CleanTailDirPath = "hio/clean"
-    AltHeadDirPath = "~"  # put in ~ as fallback when desired not permitted
+    os.path.join(os.path.sep, 'usr', 'local', 'var')
+    CleanTailDirPath = "hio" + os.path.sep + "clean"
+
+
+    AltHeadDirPath = os.path.expanduser("~")  # put in ~ as fallback when desired not permitted
     AltTailDirPath = ".hio"
-    AltCleanTailDirPath = ".hio/clean"
-    TempHeadDir = "/tmp"
+    AltCleanTailDirPath = ".hio" + os.path.sep + "clean"
+    TempHeadDir = os.path.sep + "tmp"
     TempPrefix = "hio_"
     TempSuffix = "_test"
     Perm = stat.S_ISVTX | stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR  # 0o1700==960
@@ -329,11 +332,13 @@ class Filer(hioing.Mixin):
 
             if filed or extensioned:
                 head, tail = os.path.split(path)
+                print(head)
                 if not os.path.exists(head):
                     os.makedirs(head)
                 if filed:
                     file = ocfn(path, mode=mode, perm=perm)
             else:
+                print(path)
                 os.makedirs(path)
 
         else:
@@ -358,11 +363,13 @@ class Filer(hioing.Mixin):
                 try:
                     if filed or extensioned:
                         head, tail = os.path.split(path)
+                        print(head)
                         if not os.path.exists(head):
                             os.makedirs(head)
                         if filed:
                             file = ocfn(path, mode=mode, perm=perm)
                     else:
+                        print(path)
                         os.makedirs(path)
 
                 except OSError as ex:  # use alt instead should always succeed
@@ -376,11 +383,13 @@ class Filer(hioing.Mixin):
                     if not os.path.exists(path):
                         if filed or extensioned:
                             head, tail = os.path.split(path)
+                            print(head)
                             if not os.path.exists(head):
                                 os.makedirs(head)
                             if filed:
                                 file = ocfn(path, mode=mode, perm=perm)
                         else:
+                            print(path)
                             os.makedirs(path)
                     else:
                         if filed:
@@ -398,11 +407,13 @@ class Filer(hioing.Mixin):
                     if not os.path.exists(path):
                         if filed or extensioned:
                             head, tail = os.path.split(path)
+                            print(head)
                             if not os.path.exists(head):
                                 os.makedirs(head)
                             if filed:
                                 file = ocfn(path, mode=mode, perm=perm)
                         else:
+                            print(path)
                             os.makedirs(path)
                 else:
                     if filed:

--- a/src/hio/base/filing.py
+++ b/src/hio/base/filing.py
@@ -115,7 +115,6 @@ class Filer(hioing.Mixin):
     """
     HeadDirPath = os.path.join(os.path.sep, 'usr', 'local', 'var')  # default in /usr/local/var
     TailDirPath = "hio"
-    os.path.join(os.path.sep, 'usr', 'local', 'var')
     CleanTailDirPath = os.path.join("hio", "clean")
 
 

--- a/src/hio/base/filing.py
+++ b/src/hio/base/filing.py
@@ -332,13 +332,11 @@ class Filer(hioing.Mixin):
 
             if filed or extensioned:
                 head, tail = os.path.split(path)
-                print(head)
                 if not os.path.exists(head):
                     os.makedirs(head)
                 if filed:
                     file = ocfn(path, mode=mode, perm=perm)
             else:
-                print(path)
                 os.makedirs(path)
 
         else:
@@ -363,13 +361,11 @@ class Filer(hioing.Mixin):
                 try:
                     if filed or extensioned:
                         head, tail = os.path.split(path)
-                        print(head)
                         if not os.path.exists(head):
                             os.makedirs(head)
                         if filed:
                             file = ocfn(path, mode=mode, perm=perm)
                     else:
-                        print(path)
                         os.makedirs(path)
 
                 except OSError as ex:  # use alt instead should always succeed
@@ -383,13 +379,11 @@ class Filer(hioing.Mixin):
                     if not os.path.exists(path):
                         if filed or extensioned:
                             head, tail = os.path.split(path)
-                            print(head)
                             if not os.path.exists(head):
                                 os.makedirs(head)
                             if filed:
                                 file = ocfn(path, mode=mode, perm=perm)
                         else:
-                            print(path)
                             os.makedirs(path)
                     else:
                         if filed:
@@ -407,13 +401,11 @@ class Filer(hioing.Mixin):
                     if not os.path.exists(path):
                         if filed or extensioned:
                             head, tail = os.path.split(path)
-                            print(head)
                             if not os.path.exists(head):
                                 os.makedirs(head)
                             if filed:
                                 file = ocfn(path, mode=mode, perm=perm)
                         else:
-                            print(path)
                             os.makedirs(path)
                 else:
                     if filed:

--- a/src/hio/base/filing.py
+++ b/src/hio/base/filing.py
@@ -116,13 +116,13 @@ class Filer(hioing.Mixin):
     HeadDirPath = os.path.join(os.path.sep, 'usr', 'local', 'var')  # default in /usr/local/var
     TailDirPath = "hio"
     os.path.join(os.path.sep, 'usr', 'local', 'var')
-    CleanTailDirPath = "hio" + os.path.sep + "clean"
+    CleanTailDirPath = os.path.join("hio", "clean")
 
 
     AltHeadDirPath = os.path.expanduser("~")  # put in ~ as fallback when desired not permitted
     AltTailDirPath = ".hio"
-    AltCleanTailDirPath = ".hio" + os.path.sep + "clean"
-    TempHeadDir = os.path.sep + "tmp"
+    AltCleanTailDirPath = os.path.join(".hio", "clean")
+    TempHeadDir = os.path.join(os.path.sep, "tmp")
     TempPrefix = "hio_"
     TempSuffix = "_test"
     Perm = stat.S_ISVTX | stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR  # 0o1700==960

--- a/src/hio/core/coring.py
+++ b/src/hio/core/coring.py
@@ -5,6 +5,7 @@ hio.core.coring Module
 
 import subprocess
 import socket
+import platform
 
 #import netifaces  # netifaces2
 
@@ -20,6 +21,8 @@ def normalizeHost(host):
     """
     if host == "":
         host = "0.0.0.0"
+        if platform.system() == "Windows":
+            host = "127.0.0.1"
 
     try:  # try ipv4
         info =  socket.getaddrinfo(host,
@@ -28,7 +31,7 @@ def normalizeHost(host):
                                    socket.SOCK_DGRAM,
                                    socket.IPPROTO_IP, 0)
     except socket.gaierror as ex: # try ipv6
-        if host in ("", "0.0.0.0"):
+        if host in ("", "0.0.0.0", "127.0.0.1"):
             host = "::"
 
         info =  socket.getaddrinfo(host,

--- a/src/hio/core/serial/serialing.py
+++ b/src/hio/core/serial/serialing.py
@@ -211,8 +211,6 @@ class Console():
         """
         Service puts and gets
         """
-        # Just get any available data to process it
-        self.get()
 
 
 class ConsoleDoer(doing.Doer):

--- a/src/hio/core/serial/serialing.py
+++ b/src/hio/core/serial/serialing.py
@@ -214,10 +214,25 @@ class Console():
 
 
 class ConsoleDoer(doing.Doer):
+    """
+    Basic Console Doer. Wraps console in doer context so opens and closes console
 
+    To test in WingIde must configure Debug I/O to use external console
+    See Doer for inherited attributes, properties, and methods.
+
+    Attributes:
+       .console is serial Console instance
+
+    """
 
     def __init__(self, console, **kwa):
+        """
+        Initialize instance.
 
+        Parameters:
+           console is serial Console instance
+
+        """
         super(ConsoleDoer, self).__init__(**kwa)
         self.console = console
 
@@ -542,7 +557,14 @@ class Device():
 
 
 class Serial():
+    """
+    Class to manage non blocking IO on serial device port using pyserial
 
+    Opens non blocking read file descriptor on serial port
+    Use instance method close to close file descriptor
+    Use instance methods get & put to read & write to serial device
+    Needs os module
+    """
     def __init__(self, port=None, speed=9600, bs=1024):
         """
         Initialization method for instance.

--- a/src/hio/core/wiring.py
+++ b/src/hio/core/wiring.py
@@ -82,7 +82,7 @@ class WireLog():
 
     TailDirPath = "wirelogs"
     AltHeadDirPath = "~"  #  put in ~ as fallback when desired dir not permitted
-    TempHeadDir = os.path.sep + "tmp"
+    TempHeadDir = os.path.join(os.path.sep, "tmp")
     TempPrefix = "test_"
     TempSuffix = "_temp"
     Format = b'\n%(dx)b %(who)b:\n%(data)b\n'  # default format string as bytes

--- a/src/hio/core/wiring.py
+++ b/src/hio/core/wiring.py
@@ -77,10 +77,12 @@ class WireLog():
 
     """
     Prefix = "hio"
-    HeadDirPath = "/usr/local/var"  # default in /usr/local/var
+
+    HeadDirPath = os.path.join(os.path.sep, 'usr', 'local', 'var')  # default in /usr/local/var
+
     TailDirPath = "wirelogs"
     AltHeadDirPath = "~"  #  put in ~ as fallback when desired dir not permitted
-    TempHeadDir = "/tmp"
+    TempHeadDir = os.path.sep + "tmp"
     TempPrefix = "test_"
     TempSuffix = "_temp"
     Format = b'\n%(dx)b %(who)b:\n%(data)b\n'  # default format string as bytes

--- a/src/hio/help/ogling.py
+++ b/src/hio/help/ogling.py
@@ -100,7 +100,7 @@ class Ogler():
     HeadDirPath = os.path.join(os.path.sep, "usr", "local", "var")  # default in /usr/local/var
     TailDirPath = "logs"
     AltHeadDirPath = os.path.expanduser("~")  #  put in ~ as fallback when desired dir not permitted
-    TempHeadDir = os.path.sep + "tmp"
+    TempHeadDir = os.path.join(os.path.sep, "tmp")
     TempPrefix = "test_"
     TempSuffix = "_temp"
 

--- a/src/hio/help/ogling.py
+++ b/src/hio/help/ogling.py
@@ -5,6 +5,7 @@ hio.help.ogling module
 Provides python stdlib logging module support
 
 """
+import platform
 import sys
 import os
 import logging
@@ -96,10 +97,10 @@ class Ogler():
         count (int): backup count number of backups to keep
     """
     Prefix = "hio"
-    HeadDirPath = "/usr/local/var"  # default in /usr/local/var
+    HeadDirPath = os.path.join(os.path.sep, "usr", "local", "var")  # default in /usr/local/var
     TailDirPath = "logs"
-    AltHeadDirPath = "~"  #  put in ~ as fallback when desired dir not permitted
-    TempHeadDir = "/tmp"
+    AltHeadDirPath = os.path.expanduser("~")  #  put in ~ as fallback when desired dir not permitted
+    TempHeadDir = os.path.sep + "tmp"
     TempPrefix = "test_"
     TempSuffix = "_temp"
 
@@ -162,14 +163,16 @@ class Ogler():
         #create console handlers and assign formatters
         self.baseConsoleHandler = logging.StreamHandler()  # sys.stderr
         self.baseConsoleHandler.setFormatter(self.baseFormatter)
-        if sys.platform == 'darwin':
-            address = '/var/run/syslog'
+        if sys.platform in ('linux', 'darwin'):
+            if sys.platform == 'darwin':
+                address = '/var/run/syslog'
+            else:
+                address = '/dev/log'
+            facility = logging.handlers.SysLogHandler.LOG_USER
+            self.baseSysLogHandler = logging.handlers.SysLogHandler(address=address, facility=facility)
+            self.baseSysLogHandler.setFormatter(self.baseFormatter)
         else:
-            address = '/dev/log'
-        facility = logging.handlers.SysLogHandler.LOG_USER  # LOG_DAEMON
-        self.baseSysLogHandler = logging.handlers.SysLogHandler(address=address,
-                                                                facility=facility)
-        self.baseSysLogHandler.setFormatter(self.baseFormatter)
+            self.syslogged = False
         # SysLogHandler only appears to log at ERROR level despite the set level
         #self.baseSysLogHandler.encodePriority(self.baseSysLogHandler.LOG_USER,
                                               #self.baseSysLogHandler.LOG_DEBUG)
@@ -288,6 +291,28 @@ class Ogler():
         Parameters:
            clear is boolean, True means clear directory
         """
+        if platform.system() == 'Windows':
+            if self.filed and self.baseFileHandler:
+                self.baseFileHandler.close()
+                for name in logging.root.manager.loggerDict:
+                    logger = logging.getLogger(name)
+                    if self.baseFileHandler in logger.handlers:
+                        logger.removeHandler(self.baseFileHandler)
+
+            if self.consoled and self.baseConsoleHandler:
+                self.baseConsoleHandler.close()
+                for name in logging.root.manager.loggerDict:
+                    logger = logging.getLogger(name)
+                    if self.baseConsoleHandler in logger.handlers:
+                        logger.removeHandler(self.baseConsoleHandler)
+
+            if self.syslogged and self.baseSysLogHandler:
+                self.baseSysLogHandler.close()
+                for name in logging.root.manager.loggerDict:
+                    logger = logging.getLogger(name)
+                    if self.baseSysLogHandler in logger.handlers:
+                        logger.removeHandler(self.baseSysLogHandler)
+
         self.opened = False
         if clear or self.temp:
             self.clearDirPath()

--- a/tests/base/test_filing.py
+++ b/tests/base/test_filing.py
@@ -163,8 +163,7 @@ def test_filing():
     assert filer.path.endswith(os.path.join(".hio", "test"))
     assert os.path.exists(filer.path)
 
-    with mock.patch("os.makedirs", side_effect=conditionalMakedirs) as mocked_makedirs:
-        filer.reopen()  # reuse False so remake
+    filer.reopen()  # reuse False so remake
     assert filer.opened
     assert filer.path.endswith(os.path.join(".hio", "test"))
     assert os.path.exists(filer.path)
@@ -174,14 +173,12 @@ def test_filing():
     assert filer.path.endswith(os.path.join(".hio", "test"))
     assert os.path.exists(filer.path)
 
-    with mock.patch("os.makedirs", side_effect=conditionalMakedirs) as mocked_makedirs:
-        filer.reopen(reuse=True, clear=True)  # clear True so remake even if reuse
+    filer.reopen(reuse=True, clear=True)  # clear True so remake even if reuse
     assert filer.opened
     assert filer.path.endswith(os.path.join(".hio", "test"))
     assert os.path.exists(filer.path)
 
-    with mock.patch("os.makedirs", side_effect=conditionalMakedirs) as mocked_makedirs:
-        filer.reopen(clear=True)  # clear True so remake
+    filer.reopen(clear=True)  # clear True so remake
     assert filer.opened
     assert filer.path.endswith(os.path.join(".hio", "test"))
     assert os.path.exists(filer.path)
@@ -250,24 +247,12 @@ def test_filing():
         os.remove(filepath)
 
     headDirPath = os.path.join(os.path.sep, 'root', 'hio')
-    expectedPath = os.path.abspath(os.path.join(headDirPath, filing.Filer.TailDirPath, "conf"))
-    print(expectedPath)
-    print(headDirPath)
-    originalMakedirs = os.makedirs
-    def conditionalMakedir(path, *args, **kwargs):
-        # Check if the path being created matches the expected path
-        print(os.path.abspath(path))
-        if os.path.abspath(path) == expectedPath:
-            raise OSError("Permission denied")
-        return originalMakedirs(path, *args, **kwargs)
 
     # force altPath by using headDirPath of "/root/hio" which is not permitted
-    with mock.patch("os.makedirs", side_effect=conditionalMakedir) as mocked_makedirs:
-        filer = filing.Filer(name="test", base="conf", headDirPath=headDirPath, filed=True, reopen=False)
+    filer = filing.Filer(name="test", base="conf", headDirPath=headDirPath, filed=True, reopen=False)
     assert filer.exists(name="test", base="conf", headDirPath=headDirPath, filed=True) is False
 
-    with mock.patch("os.makedirs", side_effect=conditionalMakedir) as mocked_makedirs:
-        filer = filing.Filer(name="test", base="conf", headDirPath=headDirPath, filed=True)
+    filer = filing.Filer(name="test", base="conf", headDirPath=headDirPath, filed=True)
 
     assert filer.exists(name="test", base="conf", headDirPath=headDirPath, filed=True) is True
     assert filer.path.endswith(".hio/conf/test.text")
@@ -389,7 +374,7 @@ def test_filer_doer():
     assert [val[1] for val in doist.deeds] == [0.0, 0.0]  #  retymes
     for doer in doers:
         assert doer.filer.opened
-        assert '_test' + os.path.join(os.path.sep, 'hio', 'test') in doer.filer.path
+        assert os.path.join('_test', 'hio', 'test') in doer.filer.path
 
     doist.recur()
     assert doist.tyme == 0.03125  # on next cycle
@@ -443,8 +428,8 @@ def test_filer_doer():
     assert [val[1] for val in doist.deeds] == [0.0, 0.0]  #  retymes
     for doer in doers:
         assert doer.filer.opened
-        assert '_test' + os.path.join(os.path.sep, 'hio', 'test') in doer.filer.path
-        assert  doer.filer.path.endswith(".text")
+        assert os.path.join('_test', 'hio', 'test') in doer.filer.path
+        assert doer.filer.path.endswith(".text")
         assert doer.filer.file is not None
         assert not doer.filer.file.closed
 

--- a/tests/base/test_filing.py
+++ b/tests/base/test_filing.py
@@ -140,25 +140,16 @@ def test_filing():
         shutil.rmtree(dirpath)
 
     headDirPath = os.path.join(os.path.sep, 'root', 'hio')
+    if platform.system() == 'Windows':
+        headDirPath = os.path.join(headDirPath, 'hio')
 
-    # Compute the target path that Filer will attempt to create.
-    expectedPath = os.path.abspath(os.path.join(headDirPath, filing.Filer.TailDirPath, "test"))
-
-    # Save the original os.makedirs function.
-    originalMakedirs = os.makedirs
-
-    def conditionalMakedirs(path, *args, **kwargs):
-        # Check if the path being created matches the expected path
-        if os.path.abspath(path) == expectedPath:
-            raise OSError("Permission denied")
-        return originalMakedirs(path, *args, **kwargs)
 
     # headDirPath that is not permitted to force using AltPath
     filer = filing.Filer(name="test", headDirPath=headDirPath, reopen=False)
     assert filer.exists(name="test", headDirPath=headDirPath) is False
 
-    with mock.patch("os.makedirs", side_effect=conditionalMakedirs) as mocked_makedirs:
-        filer = filing.Filer(name="test", headDirPath=headDirPath, reopen=True)
+
+    filer = filing.Filer(name="test", headDirPath=headDirPath, reopen=True)
 
     assert filer.exists(name="test", headDirPath=headDirPath) is True
     assert filer.path.endswith(os.path.join(".hio", "test"))

--- a/tests/base/test_filing.py
+++ b/tests/base/test_filing.py
@@ -3,10 +3,12 @@
 tests.help.test_filing module
 
 """
+import platform
 import shutil
 
 import pytest
 import os
+from unittest import mock
 
 from hio import hioing
 from hio.base import doing
@@ -17,11 +19,13 @@ def test_filing():
     """
     Test Filer class
     """
-    dirpath = '/usr/local/var/hio/test'
+
+    dirpath = os.path.join(os.path.sep, 'usr', 'local', 'var', 'hio', 'test')
+
     if os.path.exists(dirpath):
         shutil.rmtree(dirpath)
 
-    altdirpath = '~/.hio/test'
+    altdirpath = os.path.join(os.path.expanduser('~'), '.hio', 'test')
     altdirpath = os.path.abspath(
                 os.path.expanduser(altdirpath))
     if os.path.exists(altdirpath):
@@ -32,33 +36,37 @@ def test_filing():
 
     filer = filing.Filer(name="test")  # defaults
     assert filer.exists(name="test") is True
-    assert filer.path.endswith("hio/test")
+    assert filer.path.endswith(os.path.join("hio", "test"))
     assert filer.opened
     assert os.path.exists(filer.path)
     assert not filer.file
     filer.close()
     assert not filer.opened
-    assert filer.path == dirpath
+
+    _, pathFiler = os.path.splitdrive(os.path.normpath(filer.path))
+    _, pathTest = os.path.splitdrive(os.path.normpath(dirpath))
+
+    assert pathFiler == pathTest
     assert os.path.exists(filer.path)
 
     filer.reopen()  # reuse False so remake
     assert filer.opened
-    assert filer.path.endswith("hio/test")
+    assert filer.path.endswith(os.path.join("hio", "test"))
     assert os.path.exists(filer.path)
 
     filer.reopen(reuse=True)  # reuse True and clear False so don't remake
     assert filer.opened
-    assert filer.path.endswith("hio/test")
+    assert filer.path.endswith(os.path.join("hio", "test"))
     assert os.path.exists(filer.path)
 
     filer.reopen(reuse=True, clear=True)  # clear True so remake even if reuse
     assert filer.opened
-    assert filer.path.endswith("hio/test")
+    assert filer.path.endswith(os.path.join("hio", "test"))
     assert os.path.exists(filer.path)
 
     filer.reopen(clear=True)  # clear True so remake
     assert filer.opened
-    assert filer.path.endswith("hio/test")
+    assert filer.path.endswith(os.path.join("hio", "test"))
     assert os.path.exists(filer.path)
 
     filer.close(clear=True)
@@ -68,18 +76,16 @@ def test_filing():
     # remove both clean and not clean
 
     # remove both alt not clean and alt clean
-    dirpath = os.path.abspath(os.path.expanduser('~/.hio/test'))
+    dirpath = os.path.join(os.path.expanduser('~'), '.hio', 'test')
     if os.path.exists(dirpath):
         shutil.rmtree(dirpath)
-    dirpath = os.path.abspath(os.path.expanduser('~/.hio/clean/test'))
+    dirpath = os.path.join(os.path.expanduser('~'), '.hio', 'clean', 'test')
     if os.path.exists(dirpath):
         shutil.rmtree(dirpath)
-    dirpath = '/usr/local/var/hio/test'  # remove both clean and not clean
+    dirpath = os.path.join(os.path.sep, 'usr', 'local', 'var', 'hio', 'test')  # remove both clean and not clean
     if os.path.exists(dirpath):
         shutil.rmtree(dirpath)
-
-
-    dirpath = '/usr/local/var/hio/clean/test'
+    dirpath = os.path.join(os.path.sep, 'usr', 'local', 'var', 'hio', 'clean', 'test')
     if os.path.exists(dirpath):
         shutil.rmtree(dirpath)
 
@@ -89,33 +95,39 @@ def test_filing():
     filer = filing.Filer(name="test", clean="true")  # defaults
     assert filer.exists(name="test", clean="true") is True
 
-    assert filer.path.endswith("hio/clean/test")
+    assert filer.path.endswith(os.path.join("hio", "clean", "test"))
     assert filer.opened
     assert os.path.exists(filer.path)
     assert not filer.file
     filer.close()
     assert not filer.opened
-    assert filer.path == dirpath
+
+    dirpath = os.path.join(os.path.sep, 'usr', 'local', 'var', 'hio', 'clean', 'test')
+
+    _, pathFiler = os.path.splitdrive(os.path.normpath(filer.path))
+    _, pathTest = os.path.splitdrive(os.path.normpath(dirpath))
+
+    assert pathFiler == pathTest
     assert os.path.exists(filer.path)
 
     filer.reopen(clean=True)  # reuse False so remake
     assert filer.opened
-    assert filer.path.endswith("hio/clean/test")
+    assert filer.path.endswith(os.path.join("hio", "clean", "test"))
     assert os.path.exists(filer.path)
 
     filer.reopen(reuse=True, clean=True)  # reuse True and clear False so don't remake
     assert filer.opened
-    assert filer.path.endswith("hio/clean/test")
+    assert filer.path.endswith(os.path.join("hio", "clean", "test"))
     assert os.path.exists(filer.path)
 
     filer.reopen(reuse=True, clear=True, clean=True)  # clear True so remake even if reuse
     assert filer.opened
-    assert filer.path.endswith("hio/clean/test")
+    assert filer.path.endswith(os.path.join("hio", "clean", "test"))
     assert os.path.exists(filer.path)
 
     filer.reopen(clear=True, clean=True)  # clear True so remake
     assert filer.opened
-    assert filer.path.endswith("hio/clean/test")
+    assert filer.path.endswith(os.path.join("hio", "clean", "test"))
     assert os.path.exists(filer.path)
 
     filer.close(clear=True)
@@ -123,50 +135,71 @@ def test_filing():
 
     # test with alt
     #dirpath = '/Users/samuel/.hio/test'
-    dirpath = os.path.abspath(os.path.expanduser('~/.hio/test'))
+    dirpath = os.path.join(os.path.expanduser('~'), '.hio', 'test')
     if os.path.exists(dirpath):
         shutil.rmtree(dirpath)
 
-    # headDirPath that is not permitted to force using AltPath
-    filer = filing.Filer(name="test", headDirPath="/root/hio", reopen=False)
-    assert filer.exists(name="test", headDirPath="/root/hio") is False
+    headDirPath = os.path.join(os.path.sep, 'root', 'hio')
 
-    filer = filing.Filer(name="test", headDirPath="/root/hio")
-    assert filer.exists(name="test", headDirPath="/root/hio") is True
-    assert filer.path.endswith(".hio/test")
+    # Compute the target path that Filer will attempt to create.
+    expectedPath = os.path.abspath(os.path.join(headDirPath, filing.Filer.TailDirPath, "test"))
+
+    # Save the original os.makedirs function.
+    originalMakedirs = os.makedirs
+
+    def conditionalMakedirs(path, *args, **kwargs):
+        # Check if the path being created matches the expected path
+        if os.path.abspath(path) == expectedPath:
+            raise OSError("Permission denied")
+        return originalMakedirs(path, *args, **kwargs)
+
+    # headDirPath that is not permitted to force using AltPath
+    filer = filing.Filer(name="test", headDirPath=headDirPath, reopen=False)
+    assert filer.exists(name="test", headDirPath=headDirPath) is False
+
+    with mock.patch("os.makedirs", side_effect=conditionalMakedirs) as mocked_makedirs:
+        filer = filing.Filer(name="test", headDirPath=headDirPath, reopen=True)
+
+    assert filer.exists(name="test", headDirPath=headDirPath) is True
+    assert filer.path.endswith(os.path.join(".hio", "test"))
+
+    assert filer.path.endswith(os.path.join(".hio", "test"))
     assert filer.opened
     assert os.path.exists(filer.path)
     assert not filer.file
     filer.close()
     assert not filer.opened
-    assert filer.path.endswith(".hio/test")
+    assert filer.path.endswith(os.path.join(".hio", "test"))
     assert os.path.exists(filer.path)
 
-    filer.reopen()  # reuse False so remake
+    with mock.patch("os.makedirs", side_effect=conditionalMakedirs) as mocked_makedirs:
+        filer.reopen()  # reuse False so remake
     assert filer.opened
-    assert filer.path.endswith(".hio/test")
+    assert filer.path.endswith(os.path.join(".hio", "test"))
     assert os.path.exists(filer.path)
 
     filer.reopen(reuse=True)  # reuse True and clear False so don't remake
     assert filer.opened
-    assert filer.path.endswith(".hio/test")
+    assert filer.path.endswith(os.path.join(".hio", "test"))
     assert os.path.exists(filer.path)
 
-    filer.reopen(reuse=True, clear=True)  # clear True so remake even if reuse
+    with mock.patch("os.makedirs", side_effect=conditionalMakedirs) as mocked_makedirs:
+        filer.reopen(reuse=True, clear=True)  # clear True so remake even if reuse
     assert filer.opened
-    assert filer.path.endswith(".hio/test")
+    assert filer.path.endswith(os.path.join(".hio", "test"))
     assert os.path.exists(filer.path)
 
-    filer.reopen(clear=True)  # clear True so remake
+    with mock.patch("os.makedirs", side_effect=conditionalMakedirs) as mocked_makedirs:
+        filer.reopen(clear=True)  # clear True so remake
     assert filer.opened
-    assert filer.path.endswith(".hio/test")
+    assert filer.path.endswith(os.path.join(".hio", "test"))
     assert os.path.exists(filer.path)
 
     filer.close(clear=True)
     assert not os.path.exists(filer.path)
 
     # Test Filer with file not dir
-    filepath = '/usr/local/var/hio/conf/test.text'
+    filepath = os.path.join(os.path.sep, 'usr', 'local', 'var', 'hio', 'conf', 'test.text')
     if os.path.exists(filepath):
         os.remove(filepath)
 
@@ -176,7 +209,7 @@ def test_filing():
 
     filer = filing.Filer(name="test", base="conf", filed=True)
     assert filer.exists(name="test", base="conf", filed=True) is True
-    assert filer.path.endswith("hio/conf/test.text")
+    assert filer.path.endswith(os.path.join("hio", "conf", "test.text"))
     assert filer.opened
     assert os.path.exists(filer.path)
     assert filer.file
@@ -190,47 +223,62 @@ def test_filing():
     filer.close()
     assert not filer.opened
     assert filer.file.closed
-    assert filer.path.endswith("hio/conf/test.text")
+    assert filer.path.endswith(os.path.join("hio", "conf", "test.text"))
     assert os.path.exists(filer.path)
 
     filer.reopen()  # reuse False so remake
     assert filer.opened
     assert not filer.file.closed
-    assert filer.path.endswith("hio/conf/test.text")
+    assert filer.path.endswith(os.path.join("hio", "conf", "test.text"))
     assert os.path.exists(filer.path)
 
     filer.reopen(reuse=True)  # reuse True and clear False so don't remake
     assert filer.opened
     assert not filer.file.closed
-    assert filer.path.endswith("hio/conf/test.text")
+    assert filer.path.endswith(os.path.join("hio", "conf", "test.text"))
     assert os.path.exists(filer.path)
 
     filer.reopen(reuse=True, clear=True)  # clear True so remake even if reuse
     assert filer.opened
     assert not filer.file.closed
-    assert filer.path.endswith("hio/conf/test.text")
+    assert filer.path.endswith(os.path.join("hio", "conf", "test.text"))
     assert os.path.exists(filer.path)
 
     filer.reopen(clear=True)  # clear True so remake
     assert filer.opened
     assert not filer.file.closed
-    assert filer.path.endswith("hio/conf/test.text")
+    assert filer.path.endswith(os.path.join("hio", "conf", "test.text"))
     assert os.path.exists(filer.path)
 
     filer.close(clear=True)
     assert not os.path.exists(filer.path)
 
     # Test Filer with file not dir and with Alt path
-    filepath = '/Users/samuel/.hio/conf/test.text'
+    filepath = os.path.join(os.path.expanduser('~'), '.hio', 'conf', 'test.text')
     if os.path.exists(filepath):
         os.remove(filepath)
 
-    # force altPath by using headDirPath of "/root/hio" which is not permitted
-    filer = filing.Filer(name="test", base="conf", headDirPath="/root/hio", filed=True, reopen=False)
-    assert filer.exists(name="test", base="conf", headDirPath="/root/hio", filed=True) is False
+    headDirPath = os.path.join(os.path.sep, 'root', 'hio')
+    expectedPath = os.path.abspath(os.path.join(headDirPath, filing.Filer.TailDirPath, "conf"))
+    print(expectedPath)
+    print(headDirPath)
+    originalMakedirs = os.makedirs
+    def conditionalMakedir(path, *args, **kwargs):
+        # Check if the path being created matches the expected path
+        print(os.path.abspath(path))
+        if os.path.abspath(path) == expectedPath:
+            raise OSError("Permission denied")
+        return originalMakedirs(path, *args, **kwargs)
 
-    filer = filing.Filer(name="test", base="conf", headDirPath="/root/hio", filed=True)
-    assert filer.exists(name="test", base="conf", headDirPath="/root/hio", filed=True) is True
+    # force altPath by using headDirPath of "/root/hio" which is not permitted
+    with mock.patch("os.makedirs", side_effect=conditionalMakedir) as mocked_makedirs:
+        filer = filing.Filer(name="test", base="conf", headDirPath=headDirPath, filed=True, reopen=False)
+    assert filer.exists(name="test", base="conf", headDirPath=headDirPath, filed=True) is False
+
+    with mock.patch("os.makedirs", side_effect=conditionalMakedir) as mocked_makedirs:
+        filer = filing.Filer(name="test", base="conf", headDirPath=headDirPath, filed=True)
+
+    assert filer.exists(name="test", base="conf", headDirPath=headDirPath, filed=True) is True
     assert filer.path.endswith(".hio/conf/test.text")
     assert filer.opened
     assert os.path.exists(filer.path)
@@ -350,7 +398,7 @@ def test_filer_doer():
     assert [val[1] for val in doist.deeds] == [0.0, 0.0]  #  retymes
     for doer in doers:
         assert doer.filer.opened
-        assert "_test/hio/test" in doer.filer.path
+        assert '_test' + os.path.join(os.path.sep, 'hio', 'test') in doer.filer.path
 
     doist.recur()
     assert doist.tyme == 0.03125  # on next cycle
@@ -404,7 +452,7 @@ def test_filer_doer():
     assert [val[1] for val in doist.deeds] == [0.0, 0.0]  #  retymes
     for doer in doers:
         assert doer.filer.opened
-        assert "_test/hio/test" in doer.filer.path
+        assert '_test' + os.path.join(os.path.sep, 'hio', 'test') in doer.filer.path
         assert  doer.filer.path.endswith(".text")
         assert doer.filer.file is not None
         assert not doer.filer.file.closed
@@ -435,8 +483,6 @@ def test_filer_doer():
         assert doer.filer.file is None
 
     """End Test"""
-
-
 
 if __name__ == "__main__":
     test_filing()

--- a/tests/core/http/falcon/test_falcon.py
+++ b/tests/core/http/falcon/test_falcon.py
@@ -501,35 +501,35 @@ def test_get_static_sink():
     assert rep.status == falcon.HTTP_OK
     assert rep.headers['content-type'] == 'text/html; charset=UTF-8'
     assert len(rep.text) > 0
-    assert rep.text == index
+    assert rep.text.replace('\r\n', '\n') == index
 
     # get default at /static  which is index.html
     rep = client.simulate_get('/static')
     assert rep.status == falcon.HTTP_OK
     assert rep.headers['content-type'] == 'text/html; charset=UTF-8'
     assert len(rep.text) > 0
-    assert rep.text == index
+    assert rep.text.replace('\r\n', '\n') == index
 
     # get default at /static/  e.g. trailing / which is index.html
     rep = client.simulate_get('/static/')
     assert rep.status == falcon.HTTP_OK
     assert rep.headers['content-type'] == 'text/html; charset=UTF-8'
     assert len(rep.text) > 0
-    assert rep.text == index
+    assert rep.text.replace('\r\n', '\n') == index
 
     # get index.html
     rep = client.simulate_get('/index.html')
     assert rep.status == falcon.HTTP_OK
     assert rep.headers['content-type'] == 'text/html; charset=UTF-8'
     assert len(rep.text) > 0
-    assert rep.text == index
+    assert rep.text.replace('\r\n', '\n') == index
 
     # get /static/index.html
     rep = client.simulate_get('/static/index.html')
     assert rep.status == falcon.HTTP_OK
     assert rep.headers['content-type'] == 'text/html; charset=UTF-8'
     assert len(rep.text) > 0
-    assert rep.text == index
+    assert rep.text.replace('\r\n', '\n') == index
 
     # attempt missing file
     rep = client.simulate_get('/static/missing.txt')
@@ -541,7 +541,7 @@ def test_get_static_sink():
     rep = client.simulate_get('/static/robots.txt')
     assert rep.status == falcon.HTTP_OK
     assert rep.headers['content-type'] == 'text/plain; charset=UTF-8'
-    assert rep.text == '# robotstxt.org\n\nUser-agent: *\n'
+    assert rep.text.replace('\r\n', '\n') == '# robotstxt.org\n\nUser-agent: *\n'
 
     # get trial.js
     rep = client.simulate_get('/static/index.js')
@@ -549,7 +549,7 @@ def test_get_static_sink():
     assert (rep.headers['content-type'] == 'application/javascript; charset=UTF-8' or
             rep.headers['content-type'] == 'text/javascript; charset=UTF-8')
     assert len(rep.text) > 0
-    assert rep.text == '// vanilla index.js\n\nm.render(document.body, "Hello world")\n'
+    assert rep.text.replace('\r\n', '\n') == '// vanilla index.js\n\nm.render(document.body, "Hello world")\n'
 
 
 def test_get_example():

--- a/tests/core/http/test_requesting.py
+++ b/tests/core/http/test_requesting.py
@@ -140,7 +140,8 @@ def test_requester_respondent_echo_tls():
     Test NonBlocking HTTPS (TLS/SSL) client
     """
     #'/Users/Load/Data/Code/public/hio/tests/core/tls/certs'
-    assert certdirpath.endswith('/hio/tests/core/tls/certs')
+    assert certdirpath.endswith(os.path.join(os.path.sep, 'hio', 'tests', 'core', 'tls', 'certs'))
+
 
     #serverKeypath = '/etc/pki/tls/certs/server_key.pem'  # local server private key
     #serverCertpath = '/etc/pki/tls/certs/server_cert.pem'  # local server public cert

--- a/tests/core/serial/test_serialing.py
+++ b/tests/core/serial/test_serialing.py
@@ -46,17 +46,8 @@ def test_console():
     # Give the user time to see the prompt and respond
     cin = b''
     
-    # Add a timeout to avoid infinite loop if no input is provided
-    timeout = time.time() + 10  # 10 second timeout
-    
-    while not cin and time.time() < timeout:
+    while not cin:
         cin = console.get()
-        # Small delay to avoid high CPU usage
-        time.sleep(0.1)
-    
-    if not cin:
-        console.close()
-        pytest.skip("No input received within timeout period")
         
     console.put(b"You typed: " + cin + b'\n')
     assert cin ==  b'hello'
@@ -82,17 +73,9 @@ def test_console():
     console.put(cout)
     
     cin = b''
-    # Add a timeout to avoid infinite loop if no input is provided
-    timeout = time.time() + 10  # 10 second timeout
     
-    while not cin and time.time() < timeout:
+    while not cin:
         cin = console.get(bs=8)
-        # Small delay to avoid high CPU usage
-        time.sleep(0.1)
-    
-    if not cin:
-        console.close()
-        pytest.skip("No input received within timeout period")
 
     console.put(b"You typed: " + cin + b'\n')
     assert len(cin) > 8

--- a/tests/core/tcp/test_tcp.py
+++ b/tests/core/tcp/test_tcp.py
@@ -283,7 +283,7 @@ def test_tcp_basic():
         msgIn = gamma.receive()
         assert msgOut == msgIn
         msgIn = gamma.receive()
-        if 'linux' in sys.platform:
+        if 'linux' or 'windows' in sys.platform:
             assert msgIn ==  b''  # server shutdown detected not None
             assert gamma.cutoff == True
         else:
@@ -291,7 +291,7 @@ def test_tcp_basic():
             assert gamma.cutoff == False
         time.sleep(0.05)
         msgIn = gamma.receive()
-        if 'linux' in sys.platform:
+        if 'linux' or 'windows' in sys.platform:
             assert msgIn == b''  # server shutdown detected not None
             assert gamma.cutoff == True
         else:
@@ -371,7 +371,7 @@ def test_tcp_basic():
         assert msgOut == msgIn
         time.sleep(0.05)
         msgIn = ixBeta.receive()
-        if 'linux' in sys.platform:
+        if 'linux' or 'windows' in sys.platform:
             assert ixBeta.cutoff == True
             assert msgIn == b''  # server does detect shutdown
         else:

--- a/tests/core/tcp/test_tcp.py
+++ b/tests/core/tcp/test_tcp.py
@@ -5,6 +5,7 @@ tests.core.test_tcp module
 """
 import pytest
 
+import platform
 import sys
 import os
 import time
@@ -283,20 +284,20 @@ def test_tcp_basic():
         msgIn = gamma.receive()
         assert msgOut == msgIn
         msgIn = gamma.receive()
-        if 'linux' or 'windows' in sys.platform:
-            assert msgIn ==  b''  # server shutdown detected not None
-            assert gamma.cutoff == True
-        else:
-            assert msgIn == None  # server shutdown not detected
+        if platform.system() == 'Darwin':
             assert gamma.cutoff == False
+            assert  msgIn == None  # server shutdown not detected
+        else:
+            assert gamma.cutoff == True
+            assert msgIn == b''  # server shutdown detected not None
         time.sleep(0.05)
         msgIn = gamma.receive()
-        if 'linux' or 'windows' in sys.platform:
-            assert msgIn == b''  # server shutdown detected not None
-            assert gamma.cutoff == True
-        else:
-            assert msgIn == None   # server shutdown not detected
+        if platform.system() == 'Darwin':
             assert gamma.cutoff == False
+            assert  msgIn == None  # server shutdown not detected
+        else:
+            assert gamma.cutoff == True
+            assert msgIn == b''  # server shutdown detected not None
 
         ixGamma.close()  # close server connection to gamma
         del server.ixes[ixGamma.ca]
@@ -371,12 +372,12 @@ def test_tcp_basic():
         assert msgOut == msgIn
         time.sleep(0.05)
         msgIn = ixBeta.receive()
-        if 'linux' or 'windows' in sys.platform:
-            assert ixBeta.cutoff == True
-            assert msgIn == b''  # server does detect shutdown
-        else:
+        if platform.system() == 'Darwin':
             assert ixBeta.cutoff == False
             assert  msgIn == None  # server does not detect shutdown
+        else:
+            assert ixBeta.cutoff == True
+            assert msgIn == b''  # server does detect shutdown
         beta.close()
         time.sleep(0.05)
         msgIn = ixBeta.receive()

--- a/tests/core/test_wiring.py
+++ b/tests/core/test_wiring.py
@@ -29,7 +29,7 @@ def test_openWL():
         assert wl.name == "test"
         assert wl.temp == True
         assert wl.prefix == 'hio'
-        assert wl.headDirPath == wl.HeadDirPath == "/usr/local/var"
+        assert wl.headDirPath == wl.HeadDirPath == os.path.join(os.path.sep, 'usr', 'local', 'var')
         assert wl.dirPath is None  # filed == False
         assert not wl.rxl.closed
         assert not wl.txl.closed
@@ -74,7 +74,7 @@ def test_openWL():
         assert wl.name == "test"
         assert wl.temp == True
         assert wl.prefix == 'hio'
-        assert wl.headDirPath == wl.HeadDirPath == "/usr/local/var"
+        assert wl.headDirPath == wl.HeadDirPath == os.path.join(os.path.sep, 'usr', 'local', 'var')
         assert wl.dirPath is None  # filed == False
         assert not wl.rxl.closed
         assert not wl.txl.closed
@@ -132,9 +132,10 @@ def test_openWL():
         assert wl.name == "test"
         assert wl.temp == True
         assert wl.prefix == 'hio'
-        assert wl.headDirPath == wl.HeadDirPath == "/usr/local/var"
+        assert wl.headDirPath == wl.HeadDirPath == os.path.join(os.path.sep, 'usr', 'local', 'var')
         assert os.path.exists(wl.dirPath)
-        assert wl.dirPath.startswith("/tmp/hio/wirelogs/test_")
+        _, pathWl = os.path.splitdrive(os.path.normpath(wl.dirPath))
+        assert pathWl.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'wirelogs', 'test_'))
         assert wl.dirPath.endswith("_temp")
         assert not wl.rxl.closed
         assert wl.rxl.name.endswith(".rx.log")
@@ -182,9 +183,10 @@ def test_openWL():
         assert wl.name == "test"
         assert wl.temp == True
         assert wl.prefix == 'hio'
-        assert wl.headDirPath == wl.HeadDirPath == "/usr/local/var"
+        assert wl.headDirPath == wl.HeadDirPath == os.path.join(os.path.sep, 'usr', 'local', 'var')
         assert os.path.exists(wl.dirPath)
-        assert wl.dirPath.startswith("/tmp/hio/wirelogs/test_")
+        _, pathWl = os.path.splitdrive(os.path.normpath(wl.dirPath))
+        assert pathWl.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'wirelogs', 'test_'))
         assert wl.dirPath.endswith("_temp")
         assert wl.rxl is wl.txl
         assert not wl.rxl.closed
@@ -230,7 +232,6 @@ def test_openWL():
                                b'\nTx eve:\n789012\n'
                                b'\nRx bob:\nTSRWPO\n'
                                b'\nTx bob:\n321098\n')
-
     assert wl.rxl.closed
     assert wl.txl.closed
     assert not os.path.exists(wl.dirPath)
@@ -247,14 +248,17 @@ def test_openWL():
         assert wl.name == "test"
         assert wl.temp == False
         assert wl.prefix == 'hio'
-        assert wl.headDirPath == wl.HeadDirPath == "/usr/local/var"
+        assert wl.headDirPath == wl.HeadDirPath == os.path.join(os.path.sep, 'usr', 'local', 'var')
         assert os.path.exists(wl.dirPath)
-        assert wl.dirPath == '/usr/local/var/hio/wirelogs'
+        _, pathWl = os.path.splitdrive(os.path.normpath(wl.dirPath))
+        assert pathWl == os.path.join(os.path.sep, 'usr', 'local', 'var', 'hio', 'wirelogs')
         assert not wl.rxl.closed
-        assert wl.rxl.name.startswith('/usr/local/var/hio/wirelogs/test.')
+        _, pathWlRxl = os.path.splitdrive(os.path.normpath(wl.rxl.name))
+        assert pathWlRxl.startswith(os.path.join(os.path.sep, 'usr', 'local', 'var', 'hio', 'wirelogs', 'test.'))
         assert wl.rxl.name.endswith('.rx.log')
         assert not wl.txl.closed
-        assert wl.txl.name.startswith('/usr/local/var/hio/wirelogs/test.')
+        _, pathWlTxl = os.path.splitdrive(os.path.normpath(wl.txl.name))
+        assert pathWlTxl.startswith(os.path.join(os.path.sep, 'usr', 'local', 'var', 'hio', 'wirelogs', 'test.'))
         assert wl.txl.name.endswith('.tx.log')
         assert wl.opened
 
@@ -309,15 +313,19 @@ def test_openWL():
         assert wl.name == "test"
         assert wl.temp == False
         assert wl.prefix == 'hio'
-        assert wl.headDirPath == wl.HeadDirPath == "/usr/local/var"
+        assert wl.headDirPath == wl.HeadDirPath == os.path.join(os.path.sep, 'usr', 'local', 'var')
         assert os.path.exists(wl.dirPath)
-        assert wl.dirPath == '/usr/local/var/hio/wirelogs'
+
+        _, pathWl = os.path.splitdrive(os.path.normpath(wl.dirPath))
+        assert pathWl == os.path.join(os.path.sep, 'usr', 'local', 'var', 'hio', 'wirelogs')
         assert wl.rxl is wl.txl
         assert not wl.rxl.closed
-        assert wl.rxl.name.startswith('/usr/local/var/hio/wirelogs/test.')
+        _, pathWlRxl = os.path.splitdrive(os.path.normpath(wl.rxl.name))
+        assert pathWlRxl.startswith(os.path.join(os.path.sep, 'usr', 'local', 'var', 'hio', 'wirelogs', 'test.'))
         assert wl.rxl.name.endswith('.log')
         assert not wl.txl.closed
-        assert wl.txl.name.startswith('/usr/local/var/hio/wirelogs/test.')
+        _, pathWlTxl = os.path.splitdrive(os.path.normpath(wl.txl.name))
+        assert pathWlTxl.startswith(os.path.join(os.path.sep, 'usr', 'local', 'var', 'hio', 'wirelogs', 'test.'))
         assert wl.txl.name.endswith('.log')
         assert wl.opened
 

--- a/tests/core/test_wiring.py
+++ b/tests/core/test_wiring.py
@@ -134,8 +134,8 @@ def test_openWL():
         assert wl.prefix == 'hio'
         assert wl.headDirPath == wl.HeadDirPath == os.path.join(os.path.sep, 'usr', 'local', 'var')
         assert os.path.exists(wl.dirPath)
-        _, pathWl = os.path.splitdrive(os.path.normpath(wl.dirPath))
-        assert pathWl.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'wirelogs', 'test_'))
+        _, path = os.path.splitdrive(os.path.normpath(wl.dirPath))
+        assert path.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'wirelogs', 'test_'))
         assert wl.dirPath.endswith("_temp")
         assert not wl.rxl.closed
         assert wl.rxl.name.endswith(".rx.log")
@@ -185,8 +185,8 @@ def test_openWL():
         assert wl.prefix == 'hio'
         assert wl.headDirPath == wl.HeadDirPath == os.path.join(os.path.sep, 'usr', 'local', 'var')
         assert os.path.exists(wl.dirPath)
-        _, pathWl = os.path.splitdrive(os.path.normpath(wl.dirPath))
-        assert pathWl.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'wirelogs', 'test_'))
+        _, path = os.path.splitdrive(os.path.normpath(wl.dirPath))
+        assert path.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'wirelogs', 'test_'))
         assert wl.dirPath.endswith("_temp")
         assert wl.rxl is wl.txl
         assert not wl.rxl.closed
@@ -250,15 +250,15 @@ def test_openWL():
         assert wl.prefix == 'hio'
         assert wl.headDirPath == wl.HeadDirPath == os.path.join(os.path.sep, 'usr', 'local', 'var')
         assert os.path.exists(wl.dirPath)
-        _, pathWl = os.path.splitdrive(os.path.normpath(wl.dirPath))
-        assert pathWl == os.path.join(os.path.sep, 'usr', 'local', 'var', 'hio', 'wirelogs')
+        _, path = os.path.splitdrive(os.path.normpath(wl.dirPath))
+        assert path == os.path.join(os.path.sep, 'usr', 'local', 'var', 'hio', 'wirelogs')
         assert not wl.rxl.closed
-        _, pathWlRxl = os.path.splitdrive(os.path.normpath(wl.rxl.name))
-        assert pathWlRxl.startswith(os.path.join(os.path.sep, 'usr', 'local', 'var', 'hio', 'wirelogs', 'test.'))
+        _, path = os.path.splitdrive(os.path.normpath(wl.rxl.name))
+        assert path.startswith(os.path.join(os.path.sep, 'usr', 'local', 'var', 'hio', 'wirelogs', 'test.'))
         assert wl.rxl.name.endswith('.rx.log')
         assert not wl.txl.closed
-        _, pathWlTxl = os.path.splitdrive(os.path.normpath(wl.txl.name))
-        assert pathWlTxl.startswith(os.path.join(os.path.sep, 'usr', 'local', 'var', 'hio', 'wirelogs', 'test.'))
+        _, path = os.path.splitdrive(os.path.normpath(wl.txl.name))
+        assert path.startswith(os.path.join(os.path.sep, 'usr', 'local', 'var', 'hio', 'wirelogs', 'test.'))
         assert wl.txl.name.endswith('.tx.log')
         assert wl.opened
 
@@ -316,16 +316,16 @@ def test_openWL():
         assert wl.headDirPath == wl.HeadDirPath == os.path.join(os.path.sep, 'usr', 'local', 'var')
         assert os.path.exists(wl.dirPath)
 
-        _, pathWl = os.path.splitdrive(os.path.normpath(wl.dirPath))
-        assert pathWl == os.path.join(os.path.sep, 'usr', 'local', 'var', 'hio', 'wirelogs')
+        _, path = os.path.splitdrive(os.path.normpath(wl.dirPath))
+        assert path == os.path.join(os.path.sep, 'usr', 'local', 'var', 'hio', 'wirelogs')
         assert wl.rxl is wl.txl
         assert not wl.rxl.closed
-        _, pathWlRxl = os.path.splitdrive(os.path.normpath(wl.rxl.name))
-        assert pathWlRxl.startswith(os.path.join(os.path.sep, 'usr', 'local', 'var', 'hio', 'wirelogs', 'test.'))
+        _, path = os.path.splitdrive(os.path.normpath(wl.rxl.name))
+        assert path.startswith(os.path.join(os.path.sep, 'usr', 'local', 'var', 'hio', 'wirelogs', 'test.'))
         assert wl.rxl.name.endswith('.log')
         assert not wl.txl.closed
-        _, pathWlTxl = os.path.splitdrive(os.path.normpath(wl.txl.name))
-        assert pathWlTxl.startswith(os.path.join(os.path.sep, 'usr', 'local', 'var', 'hio', 'wirelogs', 'test.'))
+        _, path = os.path.splitdrive(os.path.normpath(wl.txl.name))
+        assert path.startswith(os.path.join(os.path.sep, 'usr', 'local', 'var', 'hio', 'wirelogs', 'test.'))
         assert wl.txl.name.endswith('.log')
         assert wl.opened
 

--- a/tests/core/udp/test_udp.py
+++ b/tests/core/udp/test_udp.py
@@ -33,7 +33,7 @@ def test_udp_basic():
         else:
             assert alpha.ha == ('0.0.0.0', 6101)
 
-        beta = udping.Peer(port = 6102, wl=wl)  # any interface on port 6102
+        beta = udping.Peer(name='beta',port = 6102, wl=wl)  # any interface on port 6102
         if platform.system() == 'Windows':
             beta = udping.Peer(ha=('127.0.0.1', 6102), wl=wl)
 

--- a/tests/core/udp/test_udp.py
+++ b/tests/core/udp/test_udp.py
@@ -35,7 +35,7 @@ def test_udp_basic():
 
         beta = udping.Peer(name='beta',port = 6102, wl=wl)  # any interface on port 6102
         if platform.system() == 'Windows':
-            beta = udping.Peer(ha=('127.0.0.1', 6102), wl=wl)
+            beta = udping.Peer(name='beta', ha=('127.0.0.1', 6102), wl=wl)
 
         assert not beta.opened
         assert beta.name == 'beta'

--- a/tests/core/uxd/test_peer_memoer.py
+++ b/tests/core/uxd/test_peer_memoer.py
@@ -4,6 +4,7 @@ tests.core.test_peer_memoer module
 
 """
 import os
+import platform
 
 import pytest
 
@@ -17,7 +18,8 @@ from hio.core.uxd import uxding, peermemoing
 
 def test_memoer_peer_basic():
     """Test MemoerPeer class"""
-
+    if platform.system() == "Windows":
+        return
     alpha = peermemoing.PeerMemoer(name="alpha", temp=True, size=38)
     assert alpha.name == "alpha"
     assert alpha.code == GramDex.Basic
@@ -143,7 +145,8 @@ def test_memoer_peer_basic():
 
 def test_memoer_peer_open():
     """Test MemoerPeer class with context manager openPM"""
-
+    if platform.system() == "Windows":
+        return
     with (peermemoing.openPM(name='alpha', size=38) as alpha,
           peermemoing.openPM(name='beta', size=38) as beta):
 
@@ -270,6 +273,8 @@ def test_memoer_peer_open():
 def test_peermemoer_doer():
     """Test PeerMemoerDoer class
     """
+    if platform.system() == "Windows":
+        return
     tock = 0.03125
     ticks = 4
     limit = ticks *  tock

--- a/tests/core/uxd/test_uxd.py
+++ b/tests/core/uxd/test_uxd.py
@@ -3,6 +3,8 @@
 tests  core.uxd.uxding module
 
 """
+import platform
+
 import pytest
 
 import time
@@ -20,6 +22,8 @@ def test_uxd_basic():
     """ Test the uxd connection between two peers
 
     """
+    if platform.system() == "Windows":
+        return
     tymist = tyming.Tymist()
     with (wiring.openWL(samed=True, filed=True) as wl):
 
@@ -146,7 +150,8 @@ def test_open_peer():
     """Test the uxd openPeer context manager connection between two peers
 
     """
-
+    if platform.system() == "Windows":
+        return
     tymist = tyming.Tymist()
     with (wiring.openWL(samed=True, filed=True) as wl,
           uxding.openPeer(name ="alpha", umask=0o077, wl=wl) as alpha,
@@ -271,6 +276,8 @@ def test_peer_doer():
 
     Must run in WingIDE with Debug I/O configured as external console
     """
+    if platform.system() == "Windows":
+        return
     tock = 0.03125
     ticks = 8
     limit = tock * ticks
@@ -280,7 +287,6 @@ def test_peer_doer():
     assert doist.real == True
     assert doist.limit == limit
     assert doist.doers == []
-
 
     peer = uxding.Peer(name="test", temp=True, reopen=False, umask=0o077)
     assert peer.opened == False

--- a/tests/help/test_ogling.py
+++ b/tests/help/test_ogling.py
@@ -3,6 +3,8 @@
 tests.help.test_ogling module
 
 """
+import platform
+
 import pytest
 
 import os
@@ -27,16 +29,20 @@ def test_openogler():
         assert ogler.level == logging.DEBUG
         assert ogler.temp == True
         assert ogler.prefix == 'hio'
-        assert ogler.headDirPath == ogler.HeadDirPath == "/usr/local/var"
-        assert ogler.dirPath.startswith("/tmp/hio/logs/test_")
+        assert ogler.headDirPath == ogler.HeadDirPath == os.path.join(os.path.sep, 'usr', 'local', 'var')
+        _, pathDir = os.path.splitdrive(os.path.normpath(ogler.dirPath))
+        assert pathDir.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
         assert ogler.dirPath.endswith("_temp")
-        assert ogler.path.endswith("/test.log")
+        assert ogler.path.endswith(os.path.join(os.path.sep, 'test.log'))
         assert ogler.opened
 
         # logger console: All should log  because level DEBUG
         # logger file: All should log because path created and DEBUG
         logger = ogler.getLogger()
-        assert len(logger.handlers) == 3
+        if platform.system() == 'Windows':
+            assert len(logger.handlers) == 2
+        else:
+            assert len(logger.handlers) == 3
         logger.debug("Test logger at debug level")
         logger.info("Test logger at info level")
         logger.error("Test logger at error level")
@@ -52,7 +58,10 @@ def test_openogler():
         # logger console: All should log  because level DEBUG
         # logger file: All should log because path created and DEBUG
         logger = ogler.getLogger()
-        assert len(logger.handlers) == 3
+        if platform.system() == 'Windows':
+            assert len(logger.handlers) == 2
+        else:
+            assert len(logger.handlers) == 3
         logger.debug("Test logger at debug level")
         logger.info("Test logger at info level")
         logger.error("Test logger at error level")
@@ -76,15 +85,20 @@ def test_openogler():
         assert ogler.level == logging.DEBUG
         assert ogler.temp == False
         assert ogler.prefix == 'hio'
-        assert ogler.headDirPath == ogler.HeadDirPath == "/usr/local/var"
-        assert ogler.dirPath == "/usr/local/var/hio/logs"
-        assert ogler.path == '/usr/local/var/hio/logs/mine.log'
+        assert ogler.headDirPath == ogler.HeadDirPath == os.path.join(os.path.sep, 'usr', 'local', 'var')
+        _, pathDir = os.path.splitdrive(os.path.normpath(ogler.dirPath))
+        assert pathDir.startswith(os.path.join(os.path.sep, 'usr', 'local', 'var', 'hio', 'logs'))
+        _, path = os.path.splitdrive(os.path.normpath(ogler.path))
+        assert path == os.path.join(os.path.sep, 'usr', 'local', 'var', 'hio', 'logs', 'mine.log')
         assert ogler.opened
 
         # logger console: All should log  because level DEBUG
         # logger file: All should log because path created and DEBUG
         logger = ogler.getLogger()
-        assert len(logger.handlers) == 3
+        if platform.system() == 'Windows':
+            assert len(logger.handlers) == 2
+        else:
+            assert len(logger.handlers) == 3
         logger.debug("Test logger at debug level")
         logger.info("Test logger at info level")
         logger.error("Test logger at error level")
@@ -100,7 +114,10 @@ def test_openogler():
         # logger console: All should log  because level DEBUG
         # logger file: All should log because path created and DEBUG
         logger = ogler.getLogger()
-        assert len(logger.handlers) == 3
+        if platform.system() == 'Windows':
+            assert len(logger.handlers) == 2
+        else:
+            assert len(logger.handlers) == 3
         logger.debug("Test logger at debug level")
         logger.info("Test logger at info level")
         logger.error("Test logger at error level")
@@ -138,7 +155,10 @@ def test_ogler():
     # logger console: Only Error should log  because level ERROR
     # logger file: Nothing should log because .path not created
     logger = ogler.getLogger()
-    assert len(logger.handlers) == 2
+    if platform.system() == 'Windows':
+        assert len(logger.handlers) == 1
+    else:
+        assert len(logger.handlers) == 2
     logger.debug("Test logger at debug level")
     logger.info("Test logger at info level")
     logger.error("Test logger at error level")
@@ -156,9 +176,10 @@ def test_ogler():
     ogler = ogling.Ogler(name="test", level=logging.DEBUG, temp=True,
                          reopen=True, clear=True)
     assert ogler.level == logging.DEBUG
-    assert ogler.dirPath.startswith("/tmp/hio/logs/test_")
+    _, pathDir = os.path.splitdrive(os.path.normpath(ogler.dirPath))
+    assert pathDir.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
     assert ogler.dirPath.endswith("_temp")
-    assert ogler.path.endswith("/test.log")
+    assert ogler.path.endswith(os.path.sep + "test.log")
     assert ogler.opened == True
     with open(ogler.path, 'r') as logfile:
         contents = logfile.read()
@@ -167,7 +188,10 @@ def test_ogler():
     # logger console: All should log  because level DEBUG
     # logger file: All should log because path created and DEBUG
     logger = ogler.getLogger()
-    assert len(logger.handlers) == 3
+    if platform.system() == 'Windows':
+        assert len(logger.handlers) == 2
+    else:
+        assert len(logger.handlers) == 3
     logger.debug("Test logger at debug level")
     logger.info("Test logger at info level")
     logger.error("Test logger at error level")
@@ -186,9 +210,10 @@ def test_ogler():
 
     # Test reopen but not clear so file still there
     ogler.reopen(temp=True)
-    assert ogler.dirPath.startswith("/tmp/hio/logs/test_")
+    _, pathDir = os.path.splitdrive(os.path.normpath(ogler.dirPath))
+    assert pathDir.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
     assert ogler.dirPath.endswith("_temp")
-    assert ogler.path.endswith("/test.log")
+    assert ogler.path.endswith(os.path.sep + "test.log")
     assert ogler.opened == True
     with open(ogler.path, 'r') as logfile:
         contents = logfile.read()
@@ -199,7 +224,10 @@ def test_ogler():
     # logger console: All should log  because level DEBUG
     # logger file: All should log because path created and DEBUG
     logger = ogler.getLogger()
-    assert len(logger.handlers) == 3
+    if platform.system() == 'Windows':
+        assert len(logger.handlers) == 2
+    else:
+        assert len(logger.handlers) == 3
     logger.debug("Test logger at debug level")
     logger.info("Test logger at info level")
     logger.error("Test logger at error level")
@@ -229,9 +257,10 @@ def test_ogler():
     ogler = ogling.Ogler(name="test", level=logging.DEBUG, temp=True,
                          reopen=True, clear=True, syslogged=False, filed=False)
     assert ogler.level == logging.DEBUG
-    assert ogler.dirPath.startswith("/tmp/hio/logs/test_")
+    _, pathDir = os.path.splitdrive(os.path.normpath(ogler.dirPath))
+    assert pathDir.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
     assert ogler.dirPath.endswith("_temp")
-    assert ogler.path.endswith("/test.log")
+    assert ogler.path.endswith(os.path.sep + "test.log")
     assert ogler.opened == True
     with open(ogler.path, 'r') as logfile:
         contents = logfile.read()
@@ -255,9 +284,10 @@ def test_ogler():
     ogler = ogling.Ogler(name="test", level=logging.DEBUG, temp=True,
                          reopen=True, clear=True, syslogged=False, consoled=False)
     assert ogler.level == logging.DEBUG
-    assert ogler.dirPath.startswith("/tmp/hio/logs/test_")
+    _, pathDir = os.path.splitdrive(os.path.normpath(ogler.dirPath))
+    assert pathDir.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
     assert ogler.dirPath.endswith("_temp")
-    assert ogler.path.endswith("/test.log")
+    assert ogler.path.endswith(os.path.sep + "test.log")
     assert ogler.opened == True
     with open(ogler.path, 'r') as logfile:
         contents = logfile.read()
@@ -302,7 +332,10 @@ def test_init_ogler():
     # nothing should log to file because .path not created and level critical
     # # nothing should log to console because level critical
     logger = help.ogler.getLogger()
-    assert len(logger.handlers) == 2
+    if platform.system() == 'Windows':
+        assert len(logger.handlers) == 1
+    else:
+        assert len(logger.handlers) == 2
     logger.debug("Test logger at debug level")
     logger.info("Test logger at info level")
     logger.error("Test logger at error level")
@@ -310,7 +343,10 @@ def test_init_ogler():
     help.ogler.level = logging.DEBUG
     # nothing should log because .path not created despite loggin level debug
     logger = help.ogler.getLogger()
-    assert len(logger.handlers) == 2
+    if platform.system() == 'Windows':
+        assert len(logger.handlers) == 1
+    else:
+        assert len(logger.handlers) == 2
     logger.debug("Test logger at debug level")
     logger.info("Test logger at info level")
     logger.error("Test logger at error level")
@@ -319,11 +355,16 @@ def test_init_ogler():
     help.ogler.reopen(temp=True, clear=True)
     assert help.ogler.opened
     assert help.ogler.level == logging.DEBUG
-    assert help.ogler.dirPath.startswith("/tmp/hio/logs/test_")
+
+    _, pathDir = os.path.splitdrive(os.path.normpath(help.ogler.dirPath))
+    assert pathDir.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
     assert help.ogler.dirPath.endswith("_temp")
-    assert help.ogler.path.endswith("/main.log")
+    assert help.ogler.path.endswith(os.path.sep + "main.log")
     logger = help.ogler.getLogger()
-    assert len(logger.handlers) == 3
+    if platform.system() == 'Windows':
+        assert len(logger.handlers) == 2
+    else:
+        assert len(logger.handlers) == 3
     logger.debug("Test logger at debug level")
     logger.info("Test logger at info level")
     logger.error("Test logger at error level")
@@ -338,15 +379,19 @@ def test_init_ogler():
                                           temp=True, reopen=True, clear=True)
     assert ogler.opened
     assert ogler.level == logging.DEBUG
-    assert ogler.dirPath.startswith("/tmp/hio/logs/test_")
+    _, pathDir = os.path.splitdrive(os.path.normpath(help.ogler.dirPath))
+    assert pathDir.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
     assert ogler.dirPath.endswith("_temp")
-    assert ogler.path.endswith("/test.log")
+    assert ogler.path.endswith(os.path.sep + "test.log")
     with open(ogler.path, 'r') as logfile:
         contents = logfile.read()
         assert contents == ''
 
     logger = ogler.getLogger()
-    assert len(logger.handlers) == 3
+    if platform.system() == 'Windows':
+        assert len(logger.handlers) == 2
+    else:
+        assert len(logger.handlers) == 3
     logger.debug("Test logger at debug level")
     logger.info("Test logger at info level")
     logger.error("Test logger at error level")
@@ -375,7 +420,10 @@ def test_set_levels():
     assert help.ogler.level == logging.CRITICAL  # default
     assert help.ogler.path == None
     logger = help.ogler.getLogger()
-    assert len(logger.handlers) == 2
+    if platform.system() == 'Windows':
+        assert len(logger.handlers) == 1
+    else:
+        assert len(logger.handlers) == 2
 
     # logger console: nothing should log  because level CRITICAL
     # logger file: nothing should log because .path not created
@@ -396,12 +444,16 @@ def test_set_levels():
     help.ogler.reopen(temp=True, clear=True)
     assert help.ogler.opened
     assert help.ogler.level == logging.DEBUG
-    assert help.ogler.dirPath.startswith("/tmp/hio/logs/test_")
+    _, pathDir = os.path.splitdrive(os.path.normpath(help.ogler.dirPath))
+    assert pathDir.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
     assert help.ogler.dirPath.endswith("_temp")
-    assert help.ogler.path.endswith("/main.log")
+    assert help.ogler.path.endswith(os.path.sep + "main.log")
     # recreate loggers to pick up file handler
     logger = help.ogler.getLogger()
-    assert len(logger.handlers) == 3
+    if platform.system() == 'Windows':
+        assert len(logger.handlers) == 2
+    else:
+        assert len(logger.handlers) == 3
 
     # logger console: All should log  because level DEBUG
     # logger file: All should log because .path created
@@ -421,11 +473,15 @@ def test_set_levels():
                                           temp=True, reopen=True, clear=True)
     assert ogler.opened
     assert ogler.level == logging.DEBUG
-    assert ogler.dirPath.startswith("/tmp/hio/logs/test_")
+    _, pathDir = os.path.splitdrive(os.path.normpath(help.ogler.dirPath))
+    assert pathDir.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
     assert ogler.dirPath.endswith("_temp")
-    assert ogler.path.endswith("/test.log")
+    assert ogler.path.endswith(os.path.sep + "test.log")
     # Still have 3 handlers
-    assert len(logger.handlers) == 3
+    if platform.system() == 'Windows':
+        assert len(logger.handlers) == 2
+    else:
+        assert len(logger.handlers) == 3
 
     with open(ogler.path, 'r') as logfile:
         contents = logfile.read()
@@ -443,7 +499,10 @@ def test_set_levels():
 
     # recreate loggers to pick up new path
     logger = ogler.getLogger()
-    assert len(logger.handlers) == 3
+    if platform.system() == 'Windows':
+        assert len(logger.handlers) == 2
+    else:
+        assert len(logger.handlers) == 3
 
     # logger console: All should log  because level DEBUG
     # logger file: All should log because new path on file handler

--- a/tests/help/test_ogling.py
+++ b/tests/help/test_ogling.py
@@ -30,8 +30,8 @@ def test_openogler():
         assert ogler.temp == True
         assert ogler.prefix == 'hio'
         assert ogler.headDirPath == ogler.HeadDirPath == os.path.join(os.path.sep, 'usr', 'local', 'var')
-        _, pathDir = os.path.splitdrive(os.path.normpath(ogler.dirPath))
-        assert pathDir.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
+        _, path = os.path.splitdrive(os.path.normpath(ogler.dirPath))
+        assert path.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
         assert ogler.dirPath.endswith("_temp")
         assert ogler.path.endswith(os.path.join(os.path.sep, 'test.log'))
         assert ogler.opened
@@ -86,8 +86,8 @@ def test_openogler():
         assert ogler.temp == False
         assert ogler.prefix == 'hio'
         assert ogler.headDirPath == ogler.HeadDirPath == os.path.join(os.path.sep, 'usr', 'local', 'var')
-        _, pathDir = os.path.splitdrive(os.path.normpath(ogler.dirPath))
-        assert pathDir.startswith(os.path.join(os.path.sep, 'usr', 'local', 'var', 'hio', 'logs'))
+        _, path = os.path.splitdrive(os.path.normpath(ogler.dirPath))
+        assert path.startswith(os.path.join(os.path.sep, 'usr', 'local', 'var', 'hio', 'logs'))
         _, path = os.path.splitdrive(os.path.normpath(ogler.path))
         assert path == os.path.join(os.path.sep, 'usr', 'local', 'var', 'hio', 'logs', 'mine.log')
         assert ogler.opened
@@ -176,8 +176,8 @@ def test_ogler():
     ogler = ogling.Ogler(name="test", level=logging.DEBUG, temp=True,
                          reopen=True, clear=True)
     assert ogler.level == logging.DEBUG
-    _, pathDir = os.path.splitdrive(os.path.normpath(ogler.dirPath))
-    assert pathDir.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
+    _, path = os.path.splitdrive(os.path.normpath(ogler.dirPath))
+    assert path.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
     assert ogler.dirPath.endswith("_temp")
     assert ogler.path.endswith(os.path.join(os.path.sep, "test.log"))
     assert ogler.opened == True
@@ -210,8 +210,8 @@ def test_ogler():
 
     # Test reopen but not clear so file still there
     ogler.reopen(temp=True)
-    _, pathDir = os.path.splitdrive(os.path.normpath(ogler.dirPath))
-    assert pathDir.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
+    _, path = os.path.splitdrive(os.path.normpath(ogler.dirPath))
+    assert path.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
     assert ogler.dirPath.endswith("_temp")
     assert ogler.path.endswith(os.path.join(os.path.sep, "test.log"))
     assert ogler.opened == True
@@ -257,8 +257,8 @@ def test_ogler():
     ogler = ogling.Ogler(name="test", level=logging.DEBUG, temp=True,
                          reopen=True, clear=True, syslogged=False, filed=False)
     assert ogler.level == logging.DEBUG
-    _, pathDir = os.path.splitdrive(os.path.normpath(ogler.dirPath))
-    assert pathDir.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
+    _, path = os.path.splitdrive(os.path.normpath(ogler.dirPath))
+    assert path.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
     assert ogler.dirPath.endswith("_temp")
     assert ogler.path.endswith(os.path.join(os.path.sep, "test.log"))
     assert ogler.opened == True
@@ -284,8 +284,8 @@ def test_ogler():
     ogler = ogling.Ogler(name="test", level=logging.DEBUG, temp=True,
                          reopen=True, clear=True, syslogged=False, consoled=False)
     assert ogler.level == logging.DEBUG
-    _, pathDir = os.path.splitdrive(os.path.normpath(ogler.dirPath))
-    assert pathDir.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
+    _, path = os.path.splitdrive(os.path.normpath(ogler.dirPath))
+    assert path.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
     assert ogler.dirPath.endswith("_temp")
     assert ogler.path.endswith(os.path.join(os.path.sep, "test.log"))
     assert ogler.opened == True
@@ -356,8 +356,8 @@ def test_init_ogler():
     assert help.ogler.opened
     assert help.ogler.level == logging.DEBUG
 
-    _, pathDir = os.path.splitdrive(os.path.normpath(help.ogler.dirPath))
-    assert pathDir.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
+    _, path = os.path.splitdrive(os.path.normpath(help.ogler.dirPath))
+    assert path.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
     assert help.ogler.dirPath.endswith("_temp")
     assert help.ogler.path.endswith(os.path.join(os.path.sep, "main.log"))
     logger = help.ogler.getLogger()
@@ -379,8 +379,8 @@ def test_init_ogler():
                                           temp=True, reopen=True, clear=True)
     assert ogler.opened
     assert ogler.level == logging.DEBUG
-    _, pathDir = os.path.splitdrive(os.path.normpath(help.ogler.dirPath))
-    assert pathDir.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
+    _, path = os.path.splitdrive(os.path.normpath(help.ogler.dirPath))
+    assert path.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
     assert ogler.dirPath.endswith("_temp")
     assert ogler.path.endswith(os.path.join(os.path.sep, "test.log"))
     with open(ogler.path, 'r') as logfile:
@@ -444,8 +444,8 @@ def test_set_levels():
     help.ogler.reopen(temp=True, clear=True)
     assert help.ogler.opened
     assert help.ogler.level == logging.DEBUG
-    _, pathDir = os.path.splitdrive(os.path.normpath(help.ogler.dirPath))
-    assert pathDir.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
+    _, path = os.path.splitdrive(os.path.normpath(help.ogler.dirPath))
+    assert path.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
     assert help.ogler.dirPath.endswith("_temp")
     assert help.ogler.path.endswith(os.path.join(os.path.sep, "main.log"))
     # recreate loggers to pick up file handler
@@ -473,8 +473,8 @@ def test_set_levels():
                                           temp=True, reopen=True, clear=True)
     assert ogler.opened
     assert ogler.level == logging.DEBUG
-    _, pathDir = os.path.splitdrive(os.path.normpath(help.ogler.dirPath))
-    assert pathDir.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
+    _, path = os.path.splitdrive(os.path.normpath(help.ogler.dirPath))
+    assert path.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
     assert ogler.dirPath.endswith("_temp")
     assert ogler.path.endswith(os.path.join(os.path.sep, "test.log"))
     # Still have 3 handlers

--- a/tests/help/test_ogling.py
+++ b/tests/help/test_ogling.py
@@ -179,7 +179,7 @@ def test_ogler():
     _, pathDir = os.path.splitdrive(os.path.normpath(ogler.dirPath))
     assert pathDir.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
     assert ogler.dirPath.endswith("_temp")
-    assert ogler.path.endswith(os.path.sep + "test.log")
+    assert ogler.path.endswith(os.path.join(os.path.sep, "test.log"))
     assert ogler.opened == True
     with open(ogler.path, 'r') as logfile:
         contents = logfile.read()
@@ -213,7 +213,7 @@ def test_ogler():
     _, pathDir = os.path.splitdrive(os.path.normpath(ogler.dirPath))
     assert pathDir.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
     assert ogler.dirPath.endswith("_temp")
-    assert ogler.path.endswith(os.path.sep + "test.log")
+    assert ogler.path.endswith(os.path.join(os.path.sep, "test.log"))
     assert ogler.opened == True
     with open(ogler.path, 'r') as logfile:
         contents = logfile.read()
@@ -260,7 +260,7 @@ def test_ogler():
     _, pathDir = os.path.splitdrive(os.path.normpath(ogler.dirPath))
     assert pathDir.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
     assert ogler.dirPath.endswith("_temp")
-    assert ogler.path.endswith(os.path.sep + "test.log")
+    assert ogler.path.endswith(os.path.join(os.path.sep, "test.log"))
     assert ogler.opened == True
     with open(ogler.path, 'r') as logfile:
         contents = logfile.read()
@@ -287,7 +287,7 @@ def test_ogler():
     _, pathDir = os.path.splitdrive(os.path.normpath(ogler.dirPath))
     assert pathDir.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
     assert ogler.dirPath.endswith("_temp")
-    assert ogler.path.endswith(os.path.sep + "test.log")
+    assert ogler.path.endswith(os.path.join(os.path.sep, "test.log"))
     assert ogler.opened == True
     with open(ogler.path, 'r') as logfile:
         contents = logfile.read()
@@ -359,7 +359,7 @@ def test_init_ogler():
     _, pathDir = os.path.splitdrive(os.path.normpath(help.ogler.dirPath))
     assert pathDir.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
     assert help.ogler.dirPath.endswith("_temp")
-    assert help.ogler.path.endswith(os.path.sep + "main.log")
+    assert help.ogler.path.endswith(os.path.join(os.path.sep, "main.log"))
     logger = help.ogler.getLogger()
     if platform.system() == 'Windows':
         assert len(logger.handlers) == 2
@@ -382,7 +382,7 @@ def test_init_ogler():
     _, pathDir = os.path.splitdrive(os.path.normpath(help.ogler.dirPath))
     assert pathDir.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
     assert ogler.dirPath.endswith("_temp")
-    assert ogler.path.endswith(os.path.sep + "test.log")
+    assert ogler.path.endswith(os.path.join(os.path.sep, "test.log"))
     with open(ogler.path, 'r') as logfile:
         contents = logfile.read()
         assert contents == ''
@@ -447,7 +447,7 @@ def test_set_levels():
     _, pathDir = os.path.splitdrive(os.path.normpath(help.ogler.dirPath))
     assert pathDir.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
     assert help.ogler.dirPath.endswith("_temp")
-    assert help.ogler.path.endswith(os.path.sep + "main.log")
+    assert help.ogler.path.endswith(os.path.join(os.path.sep, "main.log"))
     # recreate loggers to pick up file handler
     logger = help.ogler.getLogger()
     if platform.system() == 'Windows':
@@ -476,7 +476,7 @@ def test_set_levels():
     _, pathDir = os.path.splitdrive(os.path.normpath(help.ogler.dirPath))
     assert pathDir.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
     assert ogler.dirPath.endswith("_temp")
-    assert ogler.path.endswith(os.path.sep + "test.log")
+    assert ogler.path.endswith(os.path.join(os.path.sep, "test.log"))
     # Still have 3 handlers
     if platform.system() == 'Windows':
         assert len(logger.handlers) == 2


### PR DESCRIPTION
- Changed pathing to be OS agnostic
- Skipped sys logging on Windows
- Implemented conditional hosts:
>- 0.0.0.0 on MacOS and Linux
>- 127.0.0.1 on Windows
>- Binding to 0.0.0.0 is designed to listen on all interfaces, including 127.0.0.1, but stricter firewall settings on Windows can sometimes filter local loopback traffic when accessed via 0.0.0.0. In these cases, explicitly using 127.0.0.1 ensures that local connections are reliably routed without interference from system-wide network policies.
- Implemented conditional serialing:
>- os library on MacOS and Linux
>- msvcrt library on Windows
- Conditionally skip uxd tests on Windows
 