### PR TITLE
Feat windows CI/CD

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,14 +13,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-latest, ubuntu-latest ]
+        os: [ macos-latest, ubuntu-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.13.x
         uses: actions/setup-python@v2
         with:
           python-version: '>=3.13.1  <3.14'
-      - name: Install dependencies
+      - name: Install dependencies (Unix)
+        if: runner.os != 'Windows'
         run: |
           sudo mkdir -p /usr/local/var/hio/test
           sudo mkdir -p /usr/local/var/hio/logs
@@ -29,6 +30,15 @@ jobs:
           python -m pip install --upgrade pip
           pip install pytest
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Install dependencies (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          mkdir -Force -Path "C:usr\local\var\hio\test"
+          mkdir -Force -Path "C:usr\local\var\hio\logs"
+          mkdir -Force -Path "C:usr\local\var\hio\wirelogs"
+          python -m pip install --upgrade pip
+          pip install pytest
+          if (Test-Path -Path "requirements.txt") { pip install -r requirements.txt }
       - name: Run hio tests
         run: |
           pytest

--- a/src/hio/base/filing.py
+++ b/src/hio/base/filing.py
@@ -7,6 +7,7 @@ import os
 import stat
 import shutil
 import tempfile
+import platform
 from contextlib import contextmanager
 
 
@@ -80,7 +81,7 @@ class Filer(hioing.Mixin):
     AltHeadDirPath = os.path.expanduser("~")  # put in ~ as fallback when desired not permitted
     AltTailDirPath = ".hio"
     AltCleanTailDirPath = os.path.join(".hio", "clean")
-    TempHeadDir = os.path.join(os.path.sep, "tmp")
+    TempHeadDir = os.path.join(os.path.sep, "tmp") if platform.system() == "Darwin" else tempfile.gettempdir()
     TempPrefix = "hio_"
     TempSuffix = "_test"
     Perm = stat.S_ISVTX | stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR  # 0o1700==960

--- a/src/hio/core/serial/serialing.py
+++ b/src/hio/core/serial/serialing.py
@@ -108,6 +108,10 @@ class Console():
                 # For Windows, we'll use stdin/stdout file descriptors
                 # and rely on msvcrt for non-blocking operations
                 self.fd = 0  # Use 0 as a placeholder value for Windows console
+                # Check if stdin is a terminal on Windows
+                if not os.isatty(sys.stdin.fileno()):
+                    logger.error("Error: stdin is not a terminal on Windows\n")
+                    return False
                 # No specific open operation needed for Windows console via msvcrt
             else:
                 # Unix/macOS handling

--- a/src/hio/core/uxd/uxding.py
+++ b/src/hio/core/uxd/uxding.py
@@ -8,6 +8,7 @@ import os
 import stat
 import errno
 import socket
+import tempfile
 import shutil
 from contextlib import contextmanager
 
@@ -82,7 +83,7 @@ class Peer(filing.Filer):
     AltHeadDirPath = "~"  # put in ~ as fallback when desired not permitted
     AltTailDirPath = ".hio/uxd"
     AltCleanTailDirPath = ".hio/clean/uxd"
-    TempHeadDir = "/tmp"
+    TempHeadDir = os.path.join(os.path.sep, "tmp") if platform.system() == "Darwin" else tempfile.gettempdir()
     TempPrefix = "hio_uxd_"
     TempSuffix = "_test"
     Perm = stat.S_ISVTX | stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR  # 0o1700==960

--- a/src/hio/help/ogling.py
+++ b/src/hio/help/ogling.py
@@ -99,7 +99,7 @@ class Ogler():
     HeadDirPath = os.path.join(os.path.sep, "usr", "local", "var")  # default in /usr/local/var
     TailDirPath = "logs"
     AltHeadDirPath = os.path.expanduser("~")  #  put in ~ as fallback when desired dir not permitted
-    TempHeadDir = os.path.join(os.path.sep, "tmp")
+    TempHeadDir = os.path.join(os.path.sep, "tmp") if platform.system() == "Darwin" else tempfile.gettempdir()
     TempPrefix = "test_"
     TempSuffix = "_temp"
 

--- a/tests/base/test_doist.py
+++ b/tests/base/test_doist.py
@@ -3,6 +3,8 @@
 tests.core.test_cycling module
 
 """
+import platform
+
 import pytest
 import inspect
 
@@ -162,6 +164,10 @@ def test_doist_dos():
     """
     Test doist.do with dos generator functions not generator methods
     """
+
+    if platform.system() == 'Windows':
+        pytest.skip("Windows not supported")
+
     tock = 0.03125
     doist = doing.Doist(tock=tock)
     assert doist.tyme == 0.0  # on next cycle

--- a/tests/base/test_filing.py
+++ b/tests/base/test_filing.py
@@ -5,6 +5,7 @@ tests.help.test_filing module
 """
 import platform
 import shutil
+import tempfile
 
 import pytest
 import os
@@ -141,7 +142,7 @@ def test_filing():
 
     headDirPath = os.path.join(os.path.sep, 'root', 'hio')
     if platform.system() == 'Windows':
-        headDirPath = 'C:\\Windows\\System32\\hio'
+        headDirPath = 'C:\\System Volume Information\\hio'
     headDirPath = os.path.join(headDirPath, 'hio')
 
     # headDirPath that is not permitted to force using AltPath
@@ -251,7 +252,7 @@ def test_filing():
 
     headDirPath = os.path.join(os.path.sep, 'root', 'hio')
     if platform.system() == 'Windows':
-        headDirPath = 'C:\\Windows\\System32'
+        headDirPath = 'C:\\System Volume Information'
 
     # force altPath by using headDirPath of "/root/hio" which is not permitted
     filer = filing.Filer(name="test", base="conf", headDirPath=headDirPath, filed=True, reopen=False)
@@ -306,9 +307,9 @@ def test_filing():
 
     #test openfiler with defaults temp == True
     with filing.openFiler() as filer:
-        dirpath = os.path.join(os.path.sep, 'tmp', 'hio_hcbvwdnt_test', 'hio', 'test')
-        _, path = os.path.splitdrive(os.path.normpath(filer.path))
-        assert path.startswith(os.path.join(os.path.sep, 'tmp', 'hio_'))
+        tempDirPath = os.path.join(os.path.sep, "tmp") if platform.system() == "Darwin" else tempfile.gettempdir()
+        dirPath = os.path.join(tempDirPath, 'hio_hcbvwdnt_test', 'hio', 'test')
+        assert dirPath.startswith(os.path.join(tempDirPath, 'hio_'))
         assert filer.path.endswith(os.path.join('_test', 'hio', 'test'))
         assert filer.opened
         assert os.path.exists(filer.path)
@@ -317,9 +318,9 @@ def test_filing():
 
     #test openfiler with filed == True but otherwise defaults temp == True
     with filing.openFiler(filed=True) as filer:
-        dirpath = os.path.join(os.path.sep, 'tmp', 'hio_6t3vlv7c_test', 'hio', 'test.text')
-        _, path = os.path.splitdrive(os.path.normpath(filer.path))
-        assert path.startswith(os.path.join(os.path.sep, 'tmp', 'hio_'))
+        tempDirPath = os.path.join(os.path.sep, "tmp") if platform.system() == "Darwin" else tempfile.gettempdir()
+        dirPath = os.path.join(tempDirPath, 'hio_6t3vlv7c_test', 'hio', 'test.text')
+        assert dirPath.startswith(os.path.join(tempDirPath, 'hio_'))
         assert filer.path.endswith(os.path.join('_test', 'hio', 'test.text'))
         assert filer.opened
         assert os.path.exists(filer.path)
@@ -329,7 +330,7 @@ def test_filing():
 
     headDirPath = os.path.join(os.path.sep, 'root', 'hio')
     if platform.system() == 'Windows':
-        headDirPath = 'C:\\Windows\\System32'
+        headDirPath = 'C:\\System Volume Information'
     # test alternate path use headDirPath not permitted to force use altPath
     with filing.openFiler(filed=True, temp=False, headDirPath=headDirPath, clear=True) as  filer:
         assert filer.path.endswith(os.path.join('.hio', 'test.text'))  # uses altpath

--- a/tests/base/test_multidoing.py
+++ b/tests/base/test_multidoing.py
@@ -3,6 +3,8 @@
 tests.base.test_multidoing module
 
 """
+import platform
+
 import pytest
 
 import os
@@ -264,6 +266,10 @@ def test_boss_crew_basic():
     """Test Bosser and Crewer classes basic. Crew doist exit at doist time limit
     which causes boss doer to exit done true because no active children
     """
+
+    if platform.system() == 'Windows':
+        pytest.skip("Windows not supported")
+
     logger.debug("***** Basic Boss Crew Test *****")
     name = 'hand'  # crew hand name
     crewdoer = Crewer(tock=0.01)  # don't assign tymth now must be rewound inside subprocess
@@ -307,6 +313,10 @@ def test_boss_crew_basic_multi():
     Each Crew doist exits at doist time limit which causes boss doer to exit
     done true once all exit because no active children
     """
+
+    if platform.system() == 'Windows':
+        pytest.skip("Windows not supported")
+
     logger.debug("***** Basic Boss with Multi Crew Test *****")
     loads = []
 
@@ -373,6 +383,10 @@ def test_boss_crew_terminate():
     sends SIGTERM to Crewer
 
     """
+
+    if platform.system() == 'Windows':
+        pytest.skip("Windows not supported")
+
     logger.debug("***** Boss Crew Terminate *****")
     name = 'hand'  # crew hand name
     crewdoer = Crewer(tock=0.01)  # don't assign tymth now must be rewound inside subprocess
@@ -450,6 +464,9 @@ def test_crewer_own_exit():
     Test Bosser and Crewer where crew doer exits on own based on tyme after
     registered which causes boss doer to exit because no active children.
     """
+
+    if platform.system() == 'Windows':
+        pytest.skip("Windows not supported")
 
     logger.debug("***** Boss with Crew Own Exit *****")
     name = 'hand'  # crew hand name
@@ -539,6 +556,10 @@ def test_boss_crew_memo_cmd_end():
     """
     Test Bosser and Crewer where boss sends memo to command end of crew.
     """
+
+    if platform.system() == 'Windows':
+        pytest.skip("Windows not supported")
+
     logger.debug("***** Boss Send Memo END Command Test *****")
     name = 'hand'  # crew hand name
     crewdoer = Test1Crewer(tock=0.01)  # don't assign tymth now must be rewound inside subprocess

--- a/tests/core/http/test_clienting.py
+++ b/tests/core/http/test_clienting.py
@@ -375,7 +375,7 @@ def test_client_request_echo_port_empty():
 
     """
     with tcp.openServer(port = 80, bufsize=131072) as alpha:
-        if sys.platform == "linux":
+        if sys.platform == "linux" or sys.platform == "win32":
             assert alpha.ha == ('', 80)
             assert alpha.eha == ('127.0.0.1', 80)
         else:

--- a/tests/core/http/test_clienting.py
+++ b/tests/core/http/test_clienting.py
@@ -375,7 +375,7 @@ def test_client_request_echo_port_empty():
 
     """
     with tcp.openServer(port = 80, bufsize=131072) as alpha:
-        if sys.platform == "linux" or sys.platform == "win32":
+        if sys.platform == "linux":
             assert alpha.ha == ('', 80)
             assert alpha.eha == ('127.0.0.1', 80)
         else:

--- a/tests/core/http/test_clienting.py
+++ b/tests/core/http/test_clienting.py
@@ -375,7 +375,7 @@ def test_client_request_echo_port_empty():
 
     """
     with tcp.openServer(port = 80, bufsize=131072) as alpha:
-        if sys.platform == "linux":
+        if sys.platform == "linux" or sys.platform == "win32":
             assert alpha.ha == ('', 80)
             assert alpha.eha == ('127.0.0.1', 80)
         else:
@@ -399,7 +399,7 @@ def test_client_request_echo_port_empty():
             assert beta.requester.portOptional  # portOptional
             assert  beta.requester.lines == []
 
-            if sys.platform != "linux":
+            if sys.platform != "linux" and sys.platform != "win32":
                 # connect Client Beta to Server Alpha
                 while True:
                     beta.connector.serviceConnect()
@@ -445,7 +445,7 @@ def test_client_request_echo_port_empty():
                               b'\r\nAccept: application/json\r\n\r\n')
 
 
-            if sys.platform != "linux":
+            if sys.platform != "linux" and sys.platform != "win32":
                 beta.connector.tx(msgOut)
                 while beta.connector.txbs and not ixBeta.rxbs :
                     beta.connector.serviceSends()

--- a/tests/help/test_ogling.py
+++ b/tests/help/test_ogling.py
@@ -4,6 +4,7 @@ tests.help.test_ogling module
 
 """
 import platform
+import tempfile
 
 import pytest
 
@@ -23,6 +24,8 @@ def test_openogler():
     # used context manager to directly open an ogler  Because loggers are singletons
     # it still affects loggers.
 
+    tempDirPath = os.path.join(os.path.sep, "tmp") if platform.system() == "Darwin" else tempfile.gettempdir()
+
     with ogling.openOgler(level=logging.DEBUG) as ogler:  # default is temp = True
         assert isinstance(ogler, ogling.Ogler)
         assert ogler.name == "test"
@@ -30,8 +33,7 @@ def test_openogler():
         assert ogler.temp == True
         assert ogler.prefix == 'hio'
         assert ogler.headDirPath == ogler.HeadDirPath == os.path.join(os.path.sep, 'usr', 'local', 'var')
-        _, path = os.path.splitdrive(os.path.normpath(ogler.dirPath))
-        assert path.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
+        assert ogler.path.startswith(os.path.join(tempDirPath, 'hio', 'logs', 'test_'))
         assert ogler.dirPath.endswith("_temp")
         assert ogler.path.endswith(os.path.join(os.path.sep, 'test.log'))
         assert ogler.opened
@@ -145,6 +147,8 @@ def test_ogler():
     """
     Test Ogler class instance that builds loggers
     """
+
+    tempDirPath = os.path.join(os.path.sep, "tmp") if platform.system() == "Darwin" else tempfile.gettempdir()
     ogler = ogling.Ogler(name="test", )
     assert ogler.path is None
     assert ogler.opened == False
@@ -176,8 +180,7 @@ def test_ogler():
     ogler = ogling.Ogler(name="test", level=logging.DEBUG, temp=True,
                          reopen=True, clear=True)
     assert ogler.level == logging.DEBUG
-    _, path = os.path.splitdrive(os.path.normpath(ogler.dirPath))
-    assert path.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
+    assert ogler.path.startswith(os.path.join(tempDirPath, 'hio', 'logs', 'test_'))
     assert ogler.dirPath.endswith("_temp")
     assert ogler.path.endswith(os.path.join(os.path.sep, "test.log"))
     assert ogler.opened == True
@@ -210,8 +213,7 @@ def test_ogler():
 
     # Test reopen but not clear so file still there
     ogler.reopen(temp=True)
-    _, path = os.path.splitdrive(os.path.normpath(ogler.dirPath))
-    assert path.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
+    assert ogler.path.startswith(os.path.join(tempDirPath, 'hio', 'logs', 'test_'))
     assert ogler.dirPath.endswith("_temp")
     assert ogler.path.endswith(os.path.join(os.path.sep, "test.log"))
     assert ogler.opened == True
@@ -257,8 +259,7 @@ def test_ogler():
     ogler = ogling.Ogler(name="test", level=logging.DEBUG, temp=True,
                          reopen=True, clear=True, syslogged=False, filed=False)
     assert ogler.level == logging.DEBUG
-    _, path = os.path.splitdrive(os.path.normpath(ogler.dirPath))
-    assert path.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
+    assert ogler.path.startswith(os.path.join(tempDirPath, 'hio', 'logs', 'test_'))
     assert ogler.dirPath.endswith("_temp")
     assert ogler.path.endswith(os.path.join(os.path.sep, "test.log"))
     assert ogler.opened == True
@@ -284,8 +285,7 @@ def test_ogler():
     ogler = ogling.Ogler(name="test", level=logging.DEBUG, temp=True,
                          reopen=True, clear=True, syslogged=False, consoled=False)
     assert ogler.level == logging.DEBUG
-    _, path = os.path.splitdrive(os.path.normpath(ogler.dirPath))
-    assert path.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
+    assert path.startswith(os.path.join(tempDirPath, 'hio', 'logs', 'test_'))
     assert ogler.dirPath.endswith("_temp")
     assert ogler.path.endswith(os.path.join(os.path.sep, "test.log"))
     assert ogler.opened == True
@@ -323,6 +323,9 @@ def test_init_ogler():
     Test initOgler function for ogler global
     """
     #defined by default in help.__init__ on import of ogling
+
+    tempDirPath = os.path.join(os.path.sep, "tmp") if platform.system() == "Darwin" else tempfile.gettempdir()
+
     assert isinstance(help.ogler, ogling.Ogler)
     assert not help.ogler.opened
     assert help.ogler.level == logging.CRITICAL  # default
@@ -356,8 +359,7 @@ def test_init_ogler():
     assert help.ogler.opened
     assert help.ogler.level == logging.DEBUG
 
-    _, path = os.path.splitdrive(os.path.normpath(help.ogler.dirPath))
-    assert path.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
+    assert help.ogler.path.startswith(os.path.join(tempDirPath, 'hio', 'logs', 'test_'))
     assert help.ogler.dirPath.endswith("_temp")
     assert help.ogler.path.endswith(os.path.join(os.path.sep, "main.log"))
     logger = help.ogler.getLogger()
@@ -379,8 +381,7 @@ def test_init_ogler():
                                           temp=True, reopen=True, clear=True)
     assert ogler.opened
     assert ogler.level == logging.DEBUG
-    _, path = os.path.splitdrive(os.path.normpath(help.ogler.dirPath))
-    assert path.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
+    assert ogler.path.startswith(os.path.join(tempDirPath, 'hio', 'logs', 'test_'))
     assert ogler.dirPath.endswith("_temp")
     assert ogler.path.endswith(os.path.join(os.path.sep, "test.log"))
     with open(ogler.path, 'r') as logfile:
@@ -415,6 +416,9 @@ def test_set_levels():
     Test setLevel on preexisting loggers
     """
     #defined by default in help.__init__ on import of ogling
+
+    tempDirPath = os.path.join(os.path.sep, "tmp") if platform.system() == "Darwin" else tempfile.gettempdir()
+
     assert isinstance(help.ogler, ogling.Ogler)
     assert not help.ogler.opened
     assert help.ogler.level == logging.CRITICAL  # default
@@ -444,8 +448,7 @@ def test_set_levels():
     help.ogler.reopen(temp=True, clear=True)
     assert help.ogler.opened
     assert help.ogler.level == logging.DEBUG
-    _, path = os.path.splitdrive(os.path.normpath(help.ogler.dirPath))
-    assert path.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
+    assert help.ogler.path.startswith(os.path.join(tempDirPath, 'hio', 'logs', 'test_'))
     assert help.ogler.dirPath.endswith("_temp")
     assert help.ogler.path.endswith(os.path.join(os.path.sep, "main.log"))
     # recreate loggers to pick up file handler
@@ -473,8 +476,7 @@ def test_set_levels():
                                           temp=True, reopen=True, clear=True)
     assert ogler.opened
     assert ogler.level == logging.DEBUG
-    _, path = os.path.splitdrive(os.path.normpath(help.ogler.dirPath))
-    assert path.startswith(os.path.join(os.path.sep, 'tmp', 'hio', 'logs', 'test_'))
+    assert ogler.path.startswith(os.path.join(tempDirPath, 'hio', 'logs', 'test_'))
     assert ogler.dirPath.endswith("_temp")
     assert ogler.path.endswith(os.path.join(os.path.sep, "test.log"))
     # Still have 3 handlers

--- a/tests/help/test_timing.py
+++ b/tests/help/test_timing.py
@@ -22,7 +22,7 @@ def test_timer():
     assert timer.expired == True
 
     timer.restart(duration=0.125)
-    time.sleep(0.0001)
+    time.sleep(0.001)
     assert timer.duration == 0.125
     assert timer.elapsed > 0.0
     assert timer.remaining > 0.0
@@ -31,7 +31,7 @@ def test_timer():
     assert timer.expired == True
 
     timer.start(duration = 0.125)
-    time.sleep(0.0001)
+    time.sleep(0.001)
     assert timer.duration == 0.125
     assert timer.elapsed < 0.125
     assert timer.remaining > 0.0
@@ -40,7 +40,7 @@ def test_timer():
     assert timer.expired == True
 
     timer = Timer(duration=0.125)
-    time.sleep(0.0001)
+    time.sleep(0.001)
     assert timer.duration == 0.125
     assert timer.elapsed > 0.0
     assert timer.remaining > 0.0
@@ -49,7 +49,7 @@ def test_timer():
     assert timer.expired == True
 
     timer = Timer(duration=0.125, start=time.time() + 0.05)
-    time.sleep(0.0001)
+    time.sleep(0.001)
     assert timer.duration == 0.125
     assert timer.elapsed < 0.0
     assert timer.remaining > 0.125
@@ -58,7 +58,7 @@ def test_timer():
     assert timer.expired == True
 
     timer = Timer(duration=0.125, start=time.time() - 0.05)
-    time.sleep(0.0001)
+    time.sleep(0.001)
     assert timer.duration == 0.125
     assert timer.elapsed > 0.0
     assert timer.remaining < 0.075
@@ -74,6 +74,7 @@ def test_monotimer():
     """
     timer = MonoTimer()
     assert timer.duration == 0.0
+    time.sleep(0.001)
     assert timer.elapsed > 0.0
     assert timer.remaining < 0.0
     assert timer.expired == True
@@ -96,6 +97,7 @@ def test_monotimer():
 
     timer = MonoTimer(duration=0.125)
     assert timer.duration == 0.125
+    time.sleep(0.001)
     assert timer.elapsed > 0.0
     assert timer.remaining > 0.0
     assert timer.expired == False
@@ -105,6 +107,7 @@ def test_monotimer():
     timer = MonoTimer(duration=0.125, start=time.time() + 0.05)  #
     assert timer.duration == 0.125
     assert timer.elapsed <= 0.0
+    time.sleep(0.001)
     assert timer.remaining < 0.125
     assert timer.expired == False
     time.sleep(0.175)
@@ -112,6 +115,7 @@ def test_monotimer():
 
     timer = MonoTimer(duration=0.125, start=time.time() - 0.05)
     assert timer.duration == 0.125
+    time.sleep(0.001)
     assert timer.elapsed > 0.0
     assert timer.remaining < 0.075
     assert timer.expired == False


### PR DESCRIPTION
- Skip multidoing and dos generator tests on windows
- Windows CI/CD
>- Changed windows inaccessible path in test_filing.py to 'C:\\System Volume Information'. previous path could be accessed in CI/CD environment
- Temp file is now detected based on os