### PR TITLE
docs: update copyright, use dynamic version, add explicit Sphinx deps

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,7 +14,7 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('./../..'))
 
-import sphinx_rtd_theme
+import hio
 
 
 # -- Project information -----------------------------------------------------
@@ -24,7 +24,6 @@ copyright = '2020-2026, Samuel M. Smith'
 author = 'Samuel M. Smith'
 
 # The full version, including alpha/beta/rc tags
-import hio
 release = hio.__version__
 version = release
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,11 +20,12 @@ import sphinx_rtd_theme
 # -- Project information -----------------------------------------------------
 
 project = 'hio'
-copyright = '2020-2021, Samuel M. Smith'
+copyright = '2020-2026, Samuel M. Smith'
 author = 'Samuel M. Smith'
 
 # The full version, including alpha/beta/rc tags
-release = '0.3.4'
+import hio
+release = hio.__version__
 version = release
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,2 +1,5 @@
 myst_parser >= 0.14.0
 sphinx-autoapi >= 1.8.1
+Sphinx >= 8.1.3
+sphinx-rtd-theme >= 3.0.1
+ordered-set >= 4.1.0


### PR DESCRIPTION
# PR: hio — Sphinx Documentation Configuration Updates (2026-01-22)

## Summary of Changes

This PR updates the Sphinx documentation configuration to use dynamic versioning, adds explicit dependency pins for reproducible builds, and fixes linting issues.

**Configuration Updates (`docs/source/conf.py`):**
- Updated copyright year from `2020-2021` to `2020-2026`
- Switched from hardcoded version `0.3.4` to dynamic `hio.__version__`
- Fixed linting errors:
  - Removed unused `sphinx_rtd_theme` import (Ruff F401)
  - Moved `hio` import to top of file (Ruff E402)

**Documentation Dependencies (`docs/source/requirements.txt`):**
- Added `Sphinx >= 8.1.3`
- Added `sphinx-rtd-theme >= 3.0.1`
- Added `ordered-set >= 4.1.0`

**No Changes Needed:**
- `sphinx.ext.viewcode` already enabled in upstream `ioflo/hio`
- `.readthedocs.yaml` already correctly configured for Python 3.13

## Testing Performed

```bash
cd docs
PYTHONPATH=/path/to/hio/src:$PYTHONPATH make clean
PYTHONPATH=/path/to/hio/src:$PYTHONPATH make html
```

- **Result:** ✅ Build succeeded
- **Output:** `build/html/index.html` generated successfully
- **Warnings:** 1485 warnings (RST formatting issues in docstrings, pre-existing)

## Known Out-of-Scope Items

The following items were noted during the audit but are not addressed in this PR:

- **Docstring Formatting:** ~1485 warnings remain regarding RST formatting (definition lists, block quotes) and duplicate object descriptions between `autoapi` and `autodoc`. These require changes to source code docstrings across multiple modules.
- **Documentation Content:** General documentation content updates and improvements are outside the scope of this configuration-focused PR.
