### PR TITLE
fix: update .readthedocs.yaml to V2 format with build section

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,17 @@
 # .readthedocs.yaml
 # Read the Docs configuration file
-# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+# See https://docs.readthedocs.com/platform/en/stable/config-file/v2.html for details
 
 # Required
 version: 2
+
+# Set the OS, Python version and system dependencies
+build:
+  os: ubuntu-24.04
+  apt_packages:
+    - libsodium-dev
+  tools:
+    python: "3.13"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -13,10 +21,12 @@ sphinx:
 formats:
    - pdf
 
-# Optionally set the version of Python and requirements required to build your docs
+# Python requirements — install hio itself (needed for import in conf.py
+# and autoapi) plus Sphinx documentation dependencies
 python:
-   version: 3.13
    install:
+   - method: pip
+     path: .
    - requirements: docs/source/requirements.txt
 
 submodules:


### PR DESCRIPTION
## Summary

Fix ReadTheDocs builds by updating `.readthedocs.yaml` to the current V2 configuration format.

## Problem

RTD builds are failing because the config uses the deprecated `python.version` key without the required `build:` section. The V2 schema requires `build.os` and `build.tools` to be present. Additionally, the hio package itself was never installed in the RTD build environment, causing `import hio` in `conf.py` and `sphinx-autoapi` source scanning to fail.

## Changes

- **Add required `build:` section** with `os: ubuntu-24.04` and `tools.python: "3.13"`
- **Replace deprecated `python.version`** key with `build.tools.python`
- **Add `libsodium-dev`** to `apt_packages` (required by pysodium dependency)
- **Install hio package** via `method: pip, path: .` so that `import hio` works in `conf.py` and autoapi can scan the source tree
- **Update RTD docs reference URL** to current domain (`docs.readthedocs.com`)

## Verification

- Sphinx docs build succeeds locally with the hio package installed
- Config validated against [RTD V2 schema](https://docs.readthedocs.com/platform/en/stable/config-file/v2.html)