### PR TITLE
chore: set RTD python to 3.14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,4 +129,4 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-.idea
+.idea.vscode

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,7 +11,7 @@ build:
   apt_packages:
     - libsodium-dev
   tools:
-    python: "3.13"
+    python: "3.14"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
## Summary
- update `.readthedocs.yaml` `build.tools.python` from `3.13` to `3.14`
- include `.gitignore` update from local branch (per request)

## Why
RTD builds are failing during install with:
`Package 'hio' requires a different Python: 3.13.3 not in '>=3.14.0'`

Aligning RTD’s python runtime with the package requirement unblocks docs builds.

## Validation
- single-file config change + `.gitignore` update
- no source code changes
- intended follow-up: trigger RTD rebuild and verify install + Sphinx steps pass