### PR TITLE
Fix RTD docstring parsing failures (hier modules + base)

### DIFF
--- a/src/hio/base/doing.py
+++ b/src/hio/base/doing.py
@@ -45,6 +45,8 @@ class Doist(tyming.Tymist):
     coroutine objects .send() method. Usually this can be wrapped try: except:
     that catches the StopIteraction
 
+    Example::
+
         async def acorf():
             return True
 
@@ -56,7 +58,7 @@ class Doist(tyming.Tymist):
             result = ex.value  # get final returned value from acoro
             assert result == True
 
-    Usage:
+    Usage::
 
         .enter method prepares deeds deque of triples (dog, retyme, doer) where
         dog is a doer generator returned by calling doer generator instances,
@@ -517,7 +519,8 @@ def doify(f, *, name=None, tock=0.0, temp=None, **opts):
     Allows multiple instances of copy, g, of generator function/method, f, each with
     unique attributes.
 
-    Usage:
+    Usage::
+
     def f():
        pass
 
@@ -551,7 +554,8 @@ def doize(*, tock=0.0, temp=None, **opts):
     DoDoer.enter().
     Only one instance of decorated function with shared attributes is allowed.
 
-    Usage:
+    Usage::
+
     @doize
     def f():
        pass
@@ -579,7 +583,8 @@ class Doer(tyming.Tymee):
     attributes that a plain generator function does not
 
     The .do method executes other methods each corresponding to one of the
-    six econtexts:
+    six econtexts::
+
         enter, recur, clean, exit, cease (forced), abort (forced)
 
     Actual context order may be one of:
@@ -852,7 +857,8 @@ class ReDoer(Doer):
             associated Tymist instance that returns Tymist .tyme. when called.
        ._tock is hidden attribute for .tock property
 
-    Test Console:
+    Test Console::
+
     ****** ReDoer Test **********
     ReDoer enter: temp=None in doist.enter next doer.do -> .enter
     ReDoer recur before yield: tock=1.0, tyme=None, count=0 in doist.enter next doer.do enter

--- a/src/hio/base/during.py
+++ b/src/hio/base/during.py
@@ -70,7 +70,7 @@ class Duror(Filer):
     Properties:
         version
 
-    File/Directory Creation Mode Notes:
+    File/Directory Creation Mode Notes::
         .Perm provides default restricted access permissions to directory and/or files
         stat.S_ISVTX | stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR
         0o1700==960
@@ -967,7 +967,7 @@ def openDuror(*, cls=None, name="test", temp=True, **kwa):
         temp (bool):  True means open in temporary directory, clear on close
                     Otherwise open in persistent directory, do not clear on close
 
-    Usage:
+    Usage::
 
     with openHolder(name="gen1") as baser1:
         baser1.env  ....
@@ -1367,7 +1367,8 @@ class Suber(SuberBase):
             data (str): decoded as utf-8 or whatever ._des provides
             None if no entry at keys
 
-        Usage:
+        Usage::
+
             Use walrus operator to catch and raise missing entry
             if (data := mydb.get(keys)) is None:
                 raise ExceptionHere
@@ -2246,4 +2247,3 @@ class Subery(Duror):
         self.dsqs = DomIoSetSuber(db=self, subkey="dsqs.")  # durable set queue
 
         return self.env
-

--- a/src/hio/base/filing.py
+++ b/src/hio/base/filing.py
@@ -64,7 +64,7 @@ class Filer(hioing.Mixin):
         _name (str): unique name for .name property
 
 
-    File/Directory Creation Mode Notes:
+    File/Directory Creation Mode Notes::
         .Perm provides default restricted access permissions to directory and/or files
         stat.S_ISVTX | stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR
         0o1700==960
@@ -551,7 +551,7 @@ def openFiler(cls=None, name="test", temp=True, reopen=True, clear=False, **kwa)
                           False means do not remove directory upon close when reopening
     See filing.Filer for other keyword parameter passthroughs
 
-    Usage:
+    Usage::
 
     with openFiler(name="bob") as filer:
 

--- a/src/hio/base/hier/acting.py
+++ b/src/hio/base/hier/acting.py
@@ -40,15 +40,17 @@ def actify(name, *, base=None, attrs=None):
     But when given a function on can decorate it with actify so that a new
     subclass of ActBase is created and registered.
 
-    Usage:
+    Usage::
+
         @actify(name="Tact")
-        def test(self, **kwa):  # signature for .act with **iops as **kwa
+        def test(self, **kwa):  # signature for .act with ``**iops`` as ``**kwa``
             assert kwa == self.iops
             return self.iops
 
         t = test(iops=dict(what=1), hello="hello", nabe=Nabe.redo)
 
-    Notes:
+    Notes::
+
     In Python, when a function is assigned as the value of a class attribute,
     the value of that attribute is automagically converted to a bound method of
     that class with injected self as first argument.
@@ -236,7 +238,7 @@ class ActBase(Mixin):
         """Make ActBase instance a callable object.
         Call its .act method with expanded self.iops as parameters
 
-        This enables compiled exec/eval str to have **iops in local scope
+        This enables compiled exec/eval str to have ``**iops`` in local scope
         """
         return self.act(**self.iops)  # put self.iops into local scope of .act
 
@@ -245,7 +247,7 @@ class ActBase(Mixin):
         """Act called by Actor. Should override in subclass.
 
         Parameters:
-            iops (dict): input/output parms, same as self.iops. Puts **iops in
+            iops (dict): input/output parms, same as self.iops. Puts ``**iops`` in
                          local scope in case act compliles exec/eval str
 
         """
@@ -394,7 +396,7 @@ class Act(ActBase):
         """Act called by ActBase.
 
         Parameters:
-            iops (dict): input/output parms, same as self.iops. Puts **iops in
+            iops (dict): input/output parms, same as self.iops. Puts ``**iops`` in
                          local scope in case act compliles exec/eval str
         """
         if callable(self.deed):  # not compilable str
@@ -531,7 +533,7 @@ class Goact(ActBase):
         """Act called by ActBase.
 
         Parameters:
-            iops (dict): input/output parms, same as self.iops. Puts **iops in
+            iops (dict): input/output parms, same as self.iops. Puts ``**iops`` in
                          local scope in case act compliles exec/eval str
 
         """
@@ -628,7 +630,7 @@ class EndAct(ActBase):
         """Act called by ActBase.
 
         Parameters:
-            iops (dict): input/output parms, same as self.iops. Puts **iops in
+            iops (dict): input/output parms, same as self.iops. Puts ``**iops`` in
                          local scope in case act compliles exec/eval str
 
         """
@@ -734,7 +736,7 @@ class Beact(ActBase):
         """Act called by ActBase.
 
         Parameters:
-            iops (dict): input/output parms, same as self.iops. Puts **iops in
+            iops (dict): input/output parms, same as self.iops. Puts ``**iops`` in
                          local scope in case act compliles exec/eval str
         """
         key, field = self.lhs
@@ -912,7 +914,7 @@ class Mark(ActBase):
         Override in subclass
 
         Parameters:
-            iops (dict): input/output parms, same as self.iops. Puts **iops in
+            iops (dict): input/output parms, same as self.iops. Puts ``**iops`` in
                          local scope in case act compliles exec/eval str
 
         """
@@ -963,7 +965,7 @@ class LapseMark(Mark):
         """Act called by ActBase.
 
         Parameters:
-            iops (dict): input/output parms, same as self.iops. Puts **iops in
+            iops (dict): input/output parms, same as self.iops. Puts ``**iops`` in
                          local scope in case act compliles exec/eval str
 
         """
@@ -1017,7 +1019,7 @@ class RelapseMark(Mark):
         """Act called by ActBase.
 
         Parameters:
-            iops (dict): input/output parms, same as self.iops. Puts **iops in
+            iops (dict): input/output parms, same as self.iops. Puts ``**iops`` in
                          local scope in case act compliles exec/eval str
 
         """
@@ -1070,7 +1072,7 @@ class Count(Mark):
         """Act called by ActBase.
 
         Parameters:
-            iops (dict): input/output parms, same as self.iops. Puts **iops in
+            iops (dict): input/output parms, same as self.iops. Puts ``**iops`` in
                          local scope in case act compliles exec/eval str
 
         """
@@ -1125,7 +1127,7 @@ class Discount(Mark):
         """Act called by ActBase.
 
         Parameters:
-            iops (dict): input/output parms, same as self.iops. Puts **iops in
+            iops (dict): input/output parms, same as self.iops. Puts ``**iops`` in
                          local scope in case act compliles exec/eval str
 
         """
@@ -1227,7 +1229,7 @@ class BagMark(Mark):
         Override in subclass
 
         Parameters:
-            iops (dict): input/output parms, same as self.iops. Puts **iops in
+            iops (dict): input/output parms, same as self.iops. Puts ``**iops`` in
                          local scope in case act compliles exec/eval str
 
         """
@@ -1280,7 +1282,7 @@ class UpdateMark(BagMark):
         """Act called by ActBase.
 
         Parameters:
-            iops (dict): input/output parms, same as self.iops. Puts **iops in
+            iops (dict): input/output parms, same as self.iops. Puts ``**iops`` in
                          local scope in case act compliles exec/eval str
 
         """
@@ -1337,7 +1339,7 @@ class ReupdateMark(BagMark):
         """Act called by ActBase.
 
         Parameters:
-            iops (dict): input/output parms, same as self.iops. Puts **iops in
+            iops (dict): input/output parms, same as self.iops. Puts ``**iops`` in
                          local scope in case act compliles exec/eval str
 
         """
@@ -1394,7 +1396,7 @@ class ChangeMark(BagMark):
         """Act called by ActBase.
 
         Parameters:
-            iops (dict): input/output parms, same as self.iops. Puts **iops in
+            iops (dict): input/output parms, same as self.iops. Puts ``**iops`` in
                          local scope in case act compliles exec/eval str
 
         """
@@ -1452,7 +1454,7 @@ class RechangeMark(BagMark):
         """Act called by ActBase.
 
         Parameters:
-            iops (dict): input/output parms, same as self.iops. Puts **iops in
+            iops (dict): input/output parms, same as self.iops. Puts ``**iops`` in
                          local scope in case act compliles exec/eval str
 
         """
@@ -1558,7 +1560,7 @@ class CloseAct(ActBase):
         """Act called by ActBase.
 
         Parameters:
-            iops (dict): input/output parms, same as self.iops. Puts **iops in
+            iops (dict): input/output parms, same as self.iops. Puts ``**iops`` in
                          local scope in case act compliles exec/eval str
 
         """

--- a/src/hio/base/hier/boxing.py
+++ b/src/hio/base/hier/boxing.py
@@ -31,7 +31,8 @@ from ...help import modify, Renam, TymeDom
 # Regular expression to detect special need 'count' condition
 LAPSEREX = r'^\s*(?P<lps>lapse)(?P<cmp>(\s|\W|\Z).*)'
 Rexlps = re.compile(LAPSEREX)  # compile is faster
-"""Usage:
+"""Usage::
+
 if m := Rexlps.match("lapse >= 1.0"):
     lps, cmp = m.group("lps","cmp")
 
@@ -42,7 +43,8 @@ if not Rexlps.match("lapse >= 1.0"):
 # Regular expression to detect special need 'count' condition
 RELAPSEREX = r'^\s*(?P<rlp>relapse)(?P<cmp>(\s|\W|\Z).*)'
 Rexrlp = re.compile(RELAPSEREX)  # compile is faster
-"""Usage:
+"""Usage::
+
 if m := Rexrlp.match("relapse >= 1.0"):
     rel, cmp = m.group("rlp","cmp")
 
@@ -54,7 +56,8 @@ if rel Rexrlp.match("relapse >= 1.0"):
 # Regular expression to detect special need 'count' condition
 COUNTREX = r'^\s*(?P<cnt>count)(?P<cmp>(\s|\W|\Z).*)'
 Rexcnt = re.compile(COUNTREX)  # compile is faster
-"""Usage:
+"""Usage::
+
 if m := Rexcnt.match("count >= 1"):
     cnt, cmp = m.group("cnt","cmp")
 
@@ -1128,9 +1131,10 @@ class Boxer(Tymee):
         Resulting act performs on of:
         H.key.field = None   when rhs is None
         H.key.field = eval(rhs)  when rhs is evalable str
-        H.key.field = rhs(**parms)  when rhs is callable
+        H.key.field = rhs(``**parms``)  when rhs is callable
 
-        Usage:
+        Usage::
+
             be(lhs, rhs)
 
         Parameters:
@@ -1256,8 +1260,8 @@ class Boxery(Mixin):
     multi-boxer boxworks
     Holds reference to current Boxer and Box being built
 
-    ****Placeholder for now. Future to be able to make multiple boxers from
-    single fun or in multiple iterations making.****
+    Placeholder for now. Future: enable multiple boxers from a single fun or
+    across multiple iterations.
 
     Attributes:
         hold (Hold): data shared by boxwork


### PR DESCRIPTION
## Summary
- Convert docstring examples to proper reST literal blocks so AutoAPI stops emitting “Unexpected indentation.”
- Escape `**iops` / `**parms` in docstrings to avoid inline-strong parsing errors.
- Remove placeholder emphasis that broke docutils parsing.

## Changes
- Add `::` + blank lines for `Usage` / `Notes` blocks.
- Escape inline strong markers in docstrings (`**iops`, `**parms` → inline literals).
- Replace placeholder emphasis in `Boxery` docstring with plain text.

## Files Touched
- libs/hio/src/hio/base/doing.py
- libs/hio/src/hio/base/during.py
- libs/hio/src/hio/base/filing.py
- libs/hio/src/hio/base/hier/acting.py
- libs/hio/src/hio/base/hier/boxing.py

## Testing
- RTD build to be re-run after merge (expected reduction in docutils errors).