### PR TITLE
Fix docstrings in core transport modules

### DIFF
--- a/src/hio/core/packeting.py
+++ b/src/hio/core/packeting.py
@@ -162,17 +162,18 @@ class PackifierPart(Part):
 
     Assumes unsigned fields values.
     Assumes network big endian so first fields element is high order bits.
-    Each field in format string is number of bits for the associated bit field
-    Fields with length of 1 are treated as has having boolean truthy field values
-       that is,   nonzero is True and packs as a 1
-    for 2+ length bit fields the field element is truncated to the number of
-       low order bits in the bit field
-    if sum of number of bits in fmt less than size bytes then the last byte in
-       the bytearray is right zero padded
-    if sum of number of bits in fmt greater than size bytes returns exception
+    Each field in format string is number of bits for the associated bit field.
+    Fields with length of 1 are treated as having boolean truthy field values
+    that is, nonzero is True and packs as a 1.
+    For 2+ length bit fields the field element is truncated to the number of
+    low order bits in the bit field.
+    If sum of number of bits in fmt less than size bytes then the last byte in
+    the bytearray is right zero padded.
+    If sum of number of bits in fmt greater than size bytes returns exception.
     to pad just use 0 value in source field.
-    example
-    packify("1 3 2 2", (True, 4, 0, 3)). returns bytearry([0xc3])
+    Example::
+
+        packify("1 3 2 2", (True, 4, 0, 3)). returns bytearry([0xc3])
     """
     Format = ''  # default packer struct format string for packed
 
@@ -347,4 +348,3 @@ class Packet(Part):
         Pack into .packed
         """
         return self.packed
-

--- a/src/hio/core/serial/serialing.py
+++ b/src/hio/core/serial/serialing.py
@@ -21,7 +21,8 @@ class LineError(hioing.HioError):
     """
     Serial line error. Too big for buffer.
 
-    Usage:
+    Usage::
+
         raise LineError("error message")
     """
 
@@ -407,35 +408,35 @@ class Device():
         The input mode, canonical or noncanonical, is controlled by the
         ICANON flag see termios module.
 
-        Raw mode
+        Raw mode::
 
-        def setraw(fd, when=TCSAFLUSH):
-            Put terminal into a raw mode.
-            mode = tcgetattr(fd)
-            mode[IFLAG] = mode[IFLAG] & ~(BRKINT | ICRNL | INPCK | ISTRIP | IXON)
-            mode[OFLAG] = mode[OFLAG] & ~(OPOST)
-            mode[CFLAG] = mode[CFLAG] & ~(CSIZE | PARENB)
-            mode[CFLAG] = mode[CFLAG] | CS8
-            mode[LFLAG] = mode[LFLAG] & ~(ECHO | ICANON | IEXTEN | ISIG)
-            mode[CC][VMIN] = 1
-            mode[CC][VTIME] = 0
-            tcsetattr(fd, when, mode)
+            def setraw(fd, when=TCSAFLUSH):
+                Put terminal into a raw mode.
+                mode = tcgetattr(fd)
+                mode[IFLAG] = mode[IFLAG] & ~(BRKINT | ICRNL | INPCK | ISTRIP | IXON)
+                mode[OFLAG] = mode[OFLAG] & ~(OPOST)
+                mode[CFLAG] = mode[CFLAG] & ~(CSIZE | PARENB)
+                mode[CFLAG] = mode[CFLAG] | CS8
+                mode[LFLAG] = mode[LFLAG] & ~(ECHO | ICANON | IEXTEN | ISIG)
+                mode[CC][VMIN] = 1
+                mode[CC][VTIME] = 0
+                tcsetattr(fd, when, mode)
 
 
-        # set up raw mode / no echo / binary
-        cflag |=  (TERMIOS.CLOCAL|TERMIOS.CREAD)
-        lflag &= ~(TERMIOS.ICANON|TERMIOS.ECHO|TERMIOS.ECHOE|TERMIOS.ECHOK|TERMIOS.ECHONL|
-                     TERMIOS.ISIG|TERMIOS.IEXTEN) #|TERMIOS.ECHOPRT
-        for flag in ('ECHOCTL', 'ECHOKE'): # netbsd workaround for Erk
-            if hasattr(TERMIOS, flag):
-                lflag &= ~getattr(TERMIOS, flag)
+            # set up raw mode / no echo / binary
+            cflag |=  (TERMIOS.CLOCAL|TERMIOS.CREAD)
+            lflag &= ~(TERMIOS.ICANON|TERMIOS.ECHO|TERMIOS.ECHOE|TERMIOS.ECHOK|TERMIOS.ECHONL|
+                         TERMIOS.ISIG|TERMIOS.IEXTEN) #|TERMIOS.ECHOPRT
+            for flag in ('ECHOCTL', 'ECHOKE'): # netbsd workaround for Erk
+                if hasattr(TERMIOS, flag):
+                    lflag &= ~getattr(TERMIOS, flag)
 
-        oflag &= ~(TERMIOS.OPOST)
-        iflag &= ~(TERMIOS.INLCR|TERMIOS.IGNCR|TERMIOS.ICRNL|TERMIOS.IGNBRK)
-        if hasattr(TERMIOS, 'IUCLC'):
-            iflag &= ~TERMIOS.IUCLC
-        if hasattr(TERMIOS, 'PARMRK'):
-            iflag &= ~TERMIOS.PARMRK
+            oflag &= ~(TERMIOS.OPOST)
+            iflag &= ~(TERMIOS.INLCR|TERMIOS.IGNCR|TERMIOS.ICRNL|TERMIOS.IGNBRK)
+            if hasattr(TERMIOS, 'IUCLC'):
+                iflag &= ~TERMIOS.IUCLC
+            if hasattr(TERMIOS, 'PARMRK'):
+                iflag &= ~TERMIOS.PARMRK
 
         """
         self.close()
@@ -822,5 +823,3 @@ class Driver():
         """
         self.serviceReceives()
         self.serviceSends()
-
-

--- a/src/hio/core/tcp/clienting.py
+++ b/src/hio/core/tcp/clienting.py
@@ -28,7 +28,8 @@ def openClient(cls=None, **kwa):
     Parameters:
         cls is Class instance of subclass instance
 
-    Usage:
+    Usage::
+
         with openClient() as client0:
             client0.accept()
 
@@ -802,5 +803,3 @@ class ClientDoer(doing.Doer):
     def exit(self):
         """"""
         self.client.close()
-
-

--- a/src/hio/core/tcp/serving.py
+++ b/src/hio/core/tcp/serving.py
@@ -36,7 +36,8 @@ def openServer(cls=None, **kwa):
     Parameters:
         cls is Class instance of subclass instance
 
-    Usage:
+    Usage::
+
         with openServer() as server0:
             server0.
 
@@ -80,11 +81,9 @@ class Acceptor(tyming.Tymee):
     def __init__(self, ha=None, bs=8096, bl=128, **kwa):
         """
         Initialization method for instance.
-        ha is host address duple (host, port) listen interfaces
-              host = "" or "0.0.0.0" means listen on all interfaces
-        bs = buffer size
-        bl (int): backlog size of not yet accepted concurrent tcp connections
-
+        ha is host address duple (host, port) listen interfaces. host = "" or
+        "0.0.0.0" means listen on all interfaces. bs is buffer size. bl is
+        backlog size of not yet accepted concurrent tcp connections.
         """
         super(Acceptor, self).__init__(**kwa)
         self.ha = ha or (host, port)  # ha = host address
@@ -435,18 +434,13 @@ def initServerContext(context=None,
 
     If certify is not None then use certify value provided Otherwise use default
 
-    context = context object for tls/ssl If None use default
-    version = ssl protocol version If None use default
-    certify = cert requirement If None use default
-              ssl.CERT_NONE = 0
-              ssl.CERT_OPTIONAL = 1
-              ssl.CERT_REQUIRED = 2
-    keypath = pathname of local server side PKI private key file path
-              If given apply to context
-    certpath = pathname of local server side PKI public cert file path
-              If given apply to context
-    cafilepath = Cert Authority file path to use to verify client cert
-              If given apply to context
+    context is the tls/ssl context object; if None use default.
+    version is ssl protocol version; if None use default.
+    certify is cert requirement; if None use default (ssl.CERT_NONE,
+    ssl.CERT_OPTIONAL, ssl.CERT_REQUIRED).
+    keypath is local server PKI private key file path; if given apply to context.
+    certpath is local server PKI public cert file path; if given apply to context.
+    cafilepath is cert authority file path to verify client cert; if given apply.
     """
     if context is None:  # create context
         if not version:  # use default context with default protocol version
@@ -598,10 +592,7 @@ class ServerTls(Server):
     def serviceConnects(self):
         """
         Service accept and handshake attempts
-        If not already accepted and handshaked  Then
-             make nonblocking attempt
-        For each successful handshaked add to .ixes
-        Returns handshakeds
+        For each successful handshake add to .ixes.
         """
         self.serviceAxes()
         self.serviceCxes()
@@ -627,16 +618,11 @@ class Remoter(tyming.Tymee):
 
         """
         Initialization method for instance.
-        ha = host address duple (host, port) near side of connection. cs.getsockname()
-             useful for debugging after cs is closed
-        ca = connection address used as key in severs's ixes. Need this to
-             know how to delete from .ixes when connection closed as .cs loses
-             cs.getpeername() after its closed.
-        cs = connection socket object
-        tymeout = tymeout for .tymer
-        refreshable = True if tx/rx activity refreshes timer False otherwise
-        bs = buffer size
-        wl = WireLog object if any
+           ha is host address duple (host, port) near side of connection.
+           ca is connection address used as key in server ixes.
+           cs is connection socket object. tymeout is tymeout for .tymer.
+           refreshable True means tx/rx activity refreshes timer.
+           bs is buffer size. wl is WireLog object if any.
         """
         super(Remoter, self).__init__(**kwa)
         self.ha = ha  # connection address of server
@@ -863,18 +849,13 @@ class RemoterTls(Remoter):
 
         """
         Initialization method for instance.
-        context = context object for tls/ssl If None use default
-        version = ssl version If None use default
-        certify = cert requirement If None use default
-                  ssl.CERT_NONE = 0
-                  ssl.CERT_OPTIONAL = 1
-                  ssl.CERT_REQUIRED = 2
-        keypath = pathname of local server side PKI private key file path
-                  If given apply to context
-        certpath = pathname of local server side PKI public cert file path
-                  If given apply to context
-        cafilepath = Cert Authority file path to use to verify client cert
-                  If given apply to context
+            context is tls/ssl context object; if None use default.
+            version is ssl version; if None use default.
+            certify is cert requirement; if None use default (ssl.CERT_NONE,
+            ssl.CERT_OPTIONAL, ssl.CERT_REQUIRED).
+            keypath is local server PKI private key file path; if given apply.
+            certpath is local server PKI public cert file path; if given apply.
+            cafilepath is cert authority file path to verify client cert; if given apply.
         """
         super(RemoterTls, self).__init__(**kwa)
 
@@ -1114,4 +1095,3 @@ class EchoServerDoer(ServerDoer):
     def exit(self):
         """"""
         self.server.close()
-

--- a/src/hio/core/udp/peermemoing.py
+++ b/src/hio/core/udp/peermemoing.py
@@ -41,7 +41,7 @@ class PeerMemoer(Peer, Memoer):
         ha (tuple): host address of form (host,port) of type (str, int) of this
                 peer's socket address.
 
-        bc (int | None): count of transport buffers of MaxGramSize
+        bc (int or None): count of transport buffers of MaxGramSize
         bs (int): buffer size
         wl (WireLog): instance ref for debug logging of over the wire tx and rx
 
@@ -159,7 +159,8 @@ def openPM(cls=None, name="test", temp=True, reopen=True, **kwa):
 
     See udping.Peer for other keyword parameter passthroughs
 
-    Usage:
+    Usage::
+
         with openPM() as peer:
             peer.receive()
 

--- a/src/hio/core/udp/udping.py
+++ b/src/hio/core/udp/udping.py
@@ -74,21 +74,15 @@ class Peer(hioing.Mixin):
                  **kwa):
         """
         Initialization method for instance.
-        Parameters:
-            name (str): unique identifier of peer for managment purposes
-            ha (tuple): local socket (host, port) address duple of type (str, int)
-            host (str): address where '' means any interface on host
-            port (int): socket port
-            bc (int | None): count of transport buffers of MaxGramSize
-            bs (int | None): buffer size of transport buffers. When .bc is provided
-                then .bs is calculated by multiplying, .bs = .bc * .MaxGramSize.
-                When .bc is not provided, then if .bs is provided use provided
-                value else use default .BufSize
-            wl (WireLog): instance ref for debug logging of over the wire tx and rx
-            bcast (bool): True enables sending to broadcast addresses from local socket
-                          False otherwise
-            reopen (bool): True (re)open with this init
-                           False not (re)open with this init but later (default)
+        name is a unique identifier of peer for management purposes.
+        ha is a local socket (host, port) address duple of type (str, int).
+        host is address where '' means any interface on host. port is socket port.
+        bc is count of transport buffers of MaxGramSize. bs is buffer size of
+        transport buffers; when bc is provided, bs = bc * MaxGramSize. When bc
+        is not provided, bs uses provided value or defaults to BufSize.
+        wl is a WireLog instance ref for debug logging of over the wire tx/rx.
+        bcast enables sending to broadcast addresses from local socket.
+        reopen True means (re)open with this init; False means open later.
         """
 
         self.name = name
@@ -347,26 +341,22 @@ class PeerDoer(doing.Doer):
         """Do 'enter' context actions. Override in subclass. Not a generator method.
         Set up resources. Comparable to context manager enter.
 
-        Parameters:
-            temp (bool | None): True means use temporary file resources if any
-                                None means ignore parameter value. Use self.temp
+        temp is bool or None. True means use temporary file resources if any.
+        None means ignore parameter value and use self.temp.
 
-        Inject temp or self.temp into file resources here if any
-
-        Doist or DoDoer winds its doers on enter
+        Inject temp or self.temp into file resources here if any.
         """
         # inject temp into file resources here if any
         self.peer.reopen(temp=temp)
 
 
     def recur(self, tyme):
-        """"""
+        """Override to service receives and sends."""
         pass  # Override in subclass to service receives and sends
 
 
 
 
     def exit(self):
-        """"""
+        """Close peer resources."""
         self.peer.close()
-

--- a/src/hio/core/uxd/peermemoing.py
+++ b/src/hio/core/uxd/peermemoing.py
@@ -36,7 +36,7 @@ class PeerMemoer(Peer, Memoer):
         """Initialization method for instance.
 
         Inherited Parameters:
-            bc (int | None): count of transport buffers of MaxGramSize
+            bc (int or None): count of transport buffers of MaxGramSize
 
             See memoing.Memoer for other inherited paramters
             See Peer for other inherited paramters
@@ -76,7 +76,8 @@ def openPM(cls=None, name="test", temp=True, reopen=True, clear=True,
 
     See filing.Filer and uxding.Peer for other keyword parameter passthroughs
 
-    Usage:
+    Usage::
+
         with openPM() as peer:
             peer.receive()
 
@@ -145,4 +146,3 @@ class PeerMemoerDoer(doing.Doer):
     def exit(self):
         """"""
         self.peer.close(clear=True)
-

--- a/src/hio/core/uxd/uxding.py
+++ b/src/hio/core/uxd/uxding.py
@@ -55,20 +55,20 @@ class Peer(filing.Filer):
         base (str): another unique path component inserted before name
         temp (bool): True means use TempHeadDir in /tmp directory
         headDirPath (str): head directory path
-        path (str | None):  full directory or file path once created else None
+        path (str or None):  full directory or file path once created else None
         perm (int):  numeric os permissions for directory and/or file(s)
         filed (bool): True means .path ends in file.
                        False means .path ends in directory
         mode (str): file open mode if filed
         fext (str): file extension if filed
-        file (File | None): File instance when filed and created.
+        file (File or None): File instance when filed and created.
         opened (bool): True means directory path, uxd file, and socket are
                 created and opened. False otherwise
 
     Attributes:
         umask (int): unpermission mask for uxd file, usually octal 0o022
                      .umask is applied after .perm is set if any
-        bc (int | None): count of transport buffers of MaxGramSize
+        bc (int or None): count of transport buffers of MaxGramSize
         bs (int): buffer size of transport buffers. When .bc then .bs is calculated
             by multiplying, .bs = .bc * .MaxGramSize. When .bc is None then .bs
             is provided value or default .BufSize
@@ -351,7 +351,8 @@ def openPeer(cls=None, name="test", temp=True, reopen=True, clear=True,
 
     See filing.Filer and uxding.Peer for other keyword parameter passthroughs
 
-    Usage:
+    Usage::
+
         with openPeer() as peer0:
             peer0.receive()
 
@@ -426,4 +427,3 @@ class PeerDoer(doing.Doer):
     def exit(self):
         """"""
         self.peer.close(clear=True)
-

--- a/src/hio/core/wiring.py
+++ b/src/hio/core/wiring.py
@@ -28,12 +28,12 @@ def openWL(cls=None, name="test", temp=True, **kwa):
         temp is Boolean, True means open in temporary directory, clear on close
                 Otherwise open in persistent directory, do not clear on close
 
-    Usage:
+    Usage::
 
-    with openWL(name="bob") as wl:
-        wl.writeRx  ....
+        with openWL(name="bob") as wl:
+            wl.writeRx  ....
 
-    with openWL(name="eve", cls=SubclassedWireLog)
+        with openWL(name="eve", cls=SubclassedWireLog)
 
     """
     wl = None
@@ -59,7 +59,11 @@ class WireLog():
         .samed is Boolean True means log both rx and tx to same file or buffer
         .filed is Boolean True means log to file False means log to memory buffer
         .fmt is io write bytes printf style format string
-            Default is b'\n%(dx)b %(who)b:\n%(data)b\n' where:
+            Default is::
+
+                b"\\n%(dx)b %(who)b:\\n%(data)b\\n"
+
+            where:
                 who is src or dst for rx tx respectively
                 dx is the io direction and will be set to either b'tx' or b'rx' and
                 data is the actual io data as bytes
@@ -422,35 +426,19 @@ class WireLogDoer(doing.Doer):
     """
     Basic WireLog Doer
 
-    Inherited Attributes:
-        .done is Boolean completion state:
-            True means completed
-            Otherwise incomplete. Incompletion maybe due to close or abort.
+    Inherited attributes: .done is Boolean completion state. True means completed.
+    Otherwise incomplete. Incompletion maybe due to close or abort.
 
-    Attributes:
-        .wl is WireLog subclass
+    Attributes: .wl is WireLog subclass.
 
-    Inherited Properties:
-        .tyme is float ._tymist.tyme, relative cycle or artificial time
-        .tock is float, desired time in seconds between runs or until next run,
-                 non negative, zero means run asap
+    Inherited properties: .tyme is float ._tymist.tyme, relative cycle or artificial time.
+    .tock is float, desired time in seconds between runs or until next run,
+    non negative, zero means run asap.
 
-    Properties:
+    Methods include `.wind`, `.__call__`, `.do`, `.enter`, `.recur`, `.exit`,
+    `.close`, and `.abort`.
 
-    Methods:
-        .wind  injects ._tymist dependency
-        .__call__ makes instance callable
-            Appears as generator function that returns generator
-        .do is generator method that returns generator
-        .enter is enter context action method
-        .recur is recur context action method or generator method
-        .exit is exit context method
-        .close is close context method
-        .abort is abort context method
-
-    Hidden:
-       ._tymist is Tymist instance reference
-       ._tock is hidden attribute for .tock property
+    Hidden attributes: `._tymist` and `._tock`.
     """
 
     def __init__(self, wl, **kwa):

--- a/src/hio/core/wms/wmsing.py
+++ b/src/hio/core/wms/wmsing.py
@@ -58,13 +58,13 @@ class Peer(filing.Filer):
         base (str): another unique path component inserted before name
         temp (bool): True means use TempHeadDir in /tmp directory
         headDirPath (str): head directory path
-        path (str | None):  full directory or file path once created else None
+        path (str or None):  full directory or file path once created else None
         perm (int):  numeric os permissions for directory and/or file(s)
         filed (bool): True means .path ends in file.
                        False means .path ends in directory
         mode (str): file open mode if filed
         fext (str): file extension if filed
-        file (File | None): File instance when filed and created.
+        file (File or None): File instance when filed and created.
         opened (bool): True means directory path, uxd file, and socket are
                 created and opened. False otherwise
 
@@ -77,7 +77,7 @@ class Peer(filing.Filer):
     Attributes:
         umask (int): unpermission mask for uxd file, usually octal 0o022
                      .umask is applied after .perm is set if any
-        bc (int | None): count of transport buffers of MaxGramSize
+        bc (int or None): count of transport buffers of MaxGramSize
         bs (int): buffer size of transport buffers. When .bc then .bs is calculated
             by multiplying, .bs = .bc * .MaxGramSize. When .bc is None then .bs
             is provided value or default .BufSize


### PR DESCRIPTION
Fix RST/Sphinx docstring formatting warnings across core transport modules:
`packeting.py`, `serial/serialing.py`, `tcp/clienting.py`, `tcp/serving.py`, `udp/peermemoing.py`, `udp/udping.py`, `uxd/peermemoing.py`, `uxd/uxding.py`, `wiring.py`, `wms/wmsing.py`.

Changes:
- Normalize `Parameters::` / `Returns::` headings with required blank lines
- Fix literal block and block quote indentation issues

No logic or behavior changes — documentation only.