### PR TITLE
Fix docstrings in help modules and hioing

### DIFF
--- a/src/hio/help/decking.py
+++ b/src/hio/help/decking.py
@@ -16,54 +16,57 @@ class Deck(deque):
     access. .push does not allow  a value of None to be added to the Deck. This
     enables retrieval  with .pull(emptive=True) which returns None when empty
     instead of raising IndexError. This allows use of the walrus operator on
-    a pull to both assign and check for empty. For example:
+    a pull to both assign and check for empty. For example::
 
-    deck.extend([False, "", []])  # falsy elements but not None
-    stuff = []
-    if x := deck.pull(emptive=True)) is not None:
-        stuff.append(x)  # do something with x
-    assert stuff == [False]
+        deck.extend([False, "", []])  # falsy elements but not None
+        stuff = []
+        if (x := deck.pull(emptive=True)) is not None:
+            stuff.append(x)  # do something with x
+        assert stuff == [False]
 
-
-    deck.extend([False, "", []])  # falsy elements but not None
-    stuff = []
-    while (x := deck.pull(emptive=True)) is not None:
-        stuff.append(x)
-    assert stuff == [False, "", []]
-    assert not deck
-
+        deck.extend([False, "", []])  # falsy elements but not None
+        stuff = []
+        while (x := deck.pull(emptive=True)) is not None:
+            stuff.append(x)
+        assert stuff == [False, "", []]
+        assert not deck
 
 
-    Local methods:
-    .push(x) = add x if x is not None to the right side of deque (like append)
-    .pull(x) = remove and return element from left side of deque (like popleft)
+
+    Local methods::
+
+        .push(x) = add x if x is not None to the right side of deque (like append)
+        .pull(x) = remove and return element from left side of deque (like popleft)
 
 
-    Inherited methods from deque:
-    .append(x)             = add x to right side of deque
-    .appendleft(x)         = add x to left side of deque
-    .clear()               = clear all items from deque leaving it a length 0
-    .count(x)              = count the number of deque elements equal to x.
-    .extend(iterable)      = append elements of iterable to right side
-    .extendleft(iterable)  = append elemets of iterable to left side
-                             (this reverses iterable)
-    .pop()                 = remove and return element from right side
-                              if empty then raise IndexError
-    .popleft()             = remove and return element from left side
-                              if empty then raise IndexError
-    .remove(x)             = remove first occurence of x left to right
-                              if not found raise ValueError
-    .rotate(n)             = rotate n steps to right if neg rotate to left
+    Inherited methods from deque::
 
-    Built in methods supported:
-    len(d)
-    reversed(d)
-    copy.copy(d)
-    copy.deepcopy(d)
-    subscripts d[0] d[-1]
+        .append(x)             = add x to right side of deque
+        .appendleft(x)         = add x to left side of deque
+        .clear()               = clear all items from deque leaving it a length 0
+        .count(x)              = count the number of deque elements equal to x.
+        .extend(iterable)      = append elements of iterable to right side
+        .extendleft(iterable)  = append elemets of iterable to left side
+                                 (this reverses iterable)
+        .pop()                 = remove and return element from right side
+                                  if empty then raise IndexError
+        .popleft()             = remove and return element from left side
+                                  if empty then raise IndexError
+        .remove(x)             = remove first occurence of x left to right
+                                  if not found raise ValueError
+        .rotate(n)             = rotate n steps to right if neg rotate to left
 
-    Attributes:
-    .maxlen  = maximum size of Deck or None if unbounded
+    Built in methods supported::
+
+        len(d)
+        reversed(d)
+        copy.copy(d)
+        copy.deepcopy(d)
+        subscripts d[0] d[-1]
+
+    Attributes::
+
+        .maxlen  = maximum size of Deck or None if unbounded
 
     """
     def __repr__(self):

--- a/src/hio/help/doming.py
+++ b/src/hio/help/doming.py
@@ -158,7 +158,7 @@ class IceRawDom(IceMapDom):
         _fromdict(cls, d: dict): return dataclass converted from dict d
 
     Class Methods:
-        _fromjson(cls, s: str|bytes): return dataclass converted from json s
+        _fromjson(cls, s: str or bytes): return dataclass converted from json s
         _fromcbor(cls, s: bytes): return dataclass converted from cbor s
         _frommgpk(cls, s: bytes): return dataclass converted from mgpk s
 
@@ -277,7 +277,7 @@ class IceTymeDom(IceRegDom):
             Assigned by @registerify decorator
 
     Non-Field Class Attributes:
-        _names (ClassVar[tuple[str]|None]): tuple of field names for class
+        _names (ClassVar[tuple[str] or None]): tuple of field names for class
             Assigned by @namify decorator
 
     Properties:
@@ -445,28 +445,38 @@ def modify(mods: MapDom|None=None, klas: Type[MapDom]=MapDom)->Callable[..., Any
     injected mods whichever was provided.
 
     Assumes wrapped function defines mods argument as a keyword only parameter
-    using '*' such as:
-       def f(name='box, over=None, *, mods=None):
+    using '*' such as::
 
-    To use inline:
+        def f(name='box', over=None, *, mods=None):
+
+    To use inline::
+
         mods = WorkDom(box=None, over=None, bepre='box', beidx=0)
         g = modify(mods)(f)
 
-    Later calling g as:
+    Later calling g as::
+
         g(name="mid", over="top")
-    Actually has mods inject as if called as:
+
+    Actually has mods injected as if called as::
+
         g(name="mid", over="top", mods=mods)
 
-    Also can be used on a method not just a function.
-       def m(self, name='box, over=None, *, mods=None):
+    Also can be used on a method not just a function::
 
-    To use inline:
+        def m(self, name='box', over=None, *, mods=None):
+
+    To use inline::
+
         mods = dict(box=None, over=None, bepre='box', beidx=0)
         m = modify(mods)(self.m)
 
-    Later calling m as:
+    Later calling m as::
+
         m(name="mid", over="top")
-    Actually has mods injectd as if called as:
+
+    Actually has mods injected as if called as::
+
         m(name="mid", over="top", mods=mods)  where self is also injected into method
 
     Since mods is a mutable collection i.e. dataclass, not an immutable object
@@ -474,17 +484,21 @@ def modify(mods: MapDom|None=None, klas: Type[MapDom]=MapDom)->Callable[..., Any
     be a lexical closure defined in the defining scope not the calling scope.
     Depends on what the use case it for it.
 
-    Example:
+    Example::
+
         mods = WorkDom(box=None, over=None, bepre='box', beidx=0)
         @modify(mods=mods)
-        def f(name="box), over=None, *, mods=None)
+        def f(name="box", over=None, *, mods=None)
 
-    Later calling f as:
+    Later calling f as::
+
         f(name="mid", over="top")
-    Actually has mods injected as if called as:
+
+    Actually has mods injected as if called as::
+
         f(name="mid", over="top", mods=mods)
 
-    But the mods in this case is from the defining scope,not the calling scope.
+    But the mods in this case is from the defining scope, not the calling scope.
 
     Likewise passing in mods=None would result in a lexical closure of mods
     with default values initially that would be shared everywhere f() is called.
@@ -516,44 +530,58 @@ def modize(mods: dict|None=None) -> Callable[..., Any]:
     injected mods whichever was provided.
 
     Assumes wrapped function defines mods argument as a keyword only parameter
-    using '*' such as:
-       def f(name='box, over=None, *, mods=None):
+    using '*' such as::
 
-    To use inline:
+        def f(name='box', over=None, *, mods=None):
+
+    To use inline::
+
         mods = dict(box=None, over=None, bepre='box', beidx=0)
         g = modize(mods)(f)
 
-    Later calling g as:
+    Later calling g as::
+
         g(name="mid", over="top")
-    Actually has mods injected as if called as:
+
+    Actually has mods injected as if called as::
+
         g(name="mid", over="top", mods=mods)
 
-    If method then works as well.
-       def f(self, name='box, over=None, *, mods=None):
+    If method then works as well::
 
-    To use inline:
+        def f(self, name='box', over=None, *, mods=None):
+
+    To use inline::
+
         mods = dict(box=None, over=None, bepre='box', beidx=0)
         f = modize(mods)(self.f)
 
-    Later calling f as:
+    Later calling f as::
+
         f(name="mid", over="top")
-    Actually has mods injected as if called as:
-        f(name="mid", over="top", mods=mods)  the self is automaticall supplied
+
+    Actually has mods injected as if called as::
+
+        f(name="mid", over="top", mods=mods)  the self is automatically supplied
 
     Since mods is a mutable collection i.e. dict, not an immutable string then
     using it as decorator could be problematic as the mods would have lexical
     defining scope not calling scope.
     Which is ok if mods has lexical module scope intentionally.
 
-    Example:
+    Example::
+
         mods = dict(box=None, over=None, bepre='box', beidx=0)
 
         @modize(mods=mods)
-        def f(name="box), over=None, *, mods=None)
+        def f(name="box", over=None, *, mods=None)
 
-    Later calling as:
+    Later calling as::
+
         f(name="mid", over="top")
-    Actually has mods injected as if called as:
+
+    Actually has mods injected as if called as::
+
         f(name="mid", over="top", mods=mods)
 
     But the mods in this case is from the defining scope not the calling scope.
@@ -720,17 +748,17 @@ class TymeDom(RegDom):
             Assigned by @namify decorator
 
     Non-Field Attributes:
-        _tymth (None|Callable): function wrapper closure returned by
+        _tymth (None or Callable): function wrapper closure returned by
             Tymist.tymen() method. When .tymth is called it returns associated
             Tymist.tyme. Provides injected dependency on Tymist cycle tyme base.
             None means not assigned yet.
             Use ._wind method to assign ._tymth after init of bag.
-        _tyme (None|Float): cycle tyme of last update of a bag field.
+        _tyme (None or Float): cycle tyme of last update of a bag field.
             None means either ._tymth as not yet been assigned or this bag's
             fields have not yet been updated.
 
     Properties:
-        _now (None|float): current tyme given by ._tymth if not None.
+        _now (None or float): current tyme given by ._tymth if not None.
 
     """
     _names: ClassVar[tuple[str]|None] = None  # Assigned in  __post_init__
@@ -761,7 +789,7 @@ class TymeDom(RegDom):
         """Gets current tyme from injected ._tymth closure from Tymist.
         tyme is float cycle time in seconds
         Returns:
-            _now (float | None): tyme from self.tymth() when wound else None
+            _now (float or None): tyme from self.tymth() when wound else None
         """
         return self._tymth() if self._tymth else None
 
@@ -773,4 +801,3 @@ class TymeDom(RegDom):
         tymist.tymth base
         """
         self._tymth = tymth
-

--- a/src/hio/help/ogling.py
+++ b/src/hio/help/ogling.py
@@ -17,23 +17,14 @@ from ..hioing import OglerError
 
 def initOgler(level=logging.CRITICAL, **kwa):
     """
-    Initialize the ogler global instance once
-    Usage:
-       # At top level of module in project
-       # assign ogler as module global instance availabe at modulename.ogler
-       ogler = hio.help.ogling.initOgler()
+    Initialize the ogler global instance once.
 
-       # module is mypackage.help  then ogler at mypackage.help.ogler
-
-    Critical is most severe to restrict logging by default
-
-    Parameters:
-        force is Boolean True is to force reinit even if global ogler is not None
-        level is default logging level
-
-    This should be called in package .__init__ to insure that global ogler is
-    defined by default. Users may then reset level and reopen log file if need be
-    before calling ogler.getLoggers()
+    Usage: assign ogler = hio.help.ogling.initOgler() at module top level.
+    Critical is most severe to restrict logging by default.
+    force is Boolean True to reinit even if global ogler is not None; level is
+    default logging level.
+    Call in package .__init__ to ensure that global ogler is defined by default.
+    Users may reset level and reopen log file before calling ogler.getLoggers().
     """
     return Ogler(level=level, **kwa)
 
@@ -77,7 +68,7 @@ class Ogler():
     Only need one Ogler per application
     Uses python stdlib logging module, logging.getLogger(name).
     Multiple calls to .getLogger() with the same name will always return a
-       reference to the same Logger object.
+    reference to the same Logger object.
 
     Attributes:
         name (str): usage specific component used in file name
@@ -357,4 +348,3 @@ class Ogler():
         if self.filed and self.opened:
             logger.addHandler(self.baseFileHandler)
         return logger
-

--- a/src/hio/help/timing.py
+++ b/src/hio/help/timing.py
@@ -10,15 +10,11 @@ from .. import hioing
 
 
 class TimerError(hioing.HioError):
-    """Generic Timer Errors
-    Usage:
-        raise TimerError("error message")
-    """
+    """Generic Timer Errors. Usage: raise TimerError("error message")."""
 
 class RetroTimerError(TimerError):
-    """Error due to real time being retrograded before start time of timer
-    Usage:
-        raise RetroTimerError("error message")
+    """Error due to real time being retrograded before start time of timer.
+    Usage: raise RetroTimerError("error message").
     """
 
 
@@ -137,13 +133,11 @@ class MonoTimer(Timer):
 
     def __init__(self, duration=0.0, start=None, retro=True):
         """Initialization method for instance.
-        Parameters:
-            duration in seconds (fractional)
-            start is float optional start time in seconds allows starting before
-               or after current time
-            retro is boolean, True means automatically shift timer whenever
-                              retrograded clock detected
-                              Otherwise raise RetroTimerError
+        duration is in seconds (fractional).
+        start is an optional start time in seconds allowing start before or
+        after current time.
+        retro is boolean. True means automatically shift timer whenever a
+        retrograded clock is detected, otherwise raise RetroTimerError.
         """
         self._start = float(start) if start is not None else time.time()
         self._stop = self._start + float(duration)  # need for default duration
@@ -330,4 +324,3 @@ def fromIso8601(dts):
     if hasattr(dts, "decode"):
         dts = dts.decode("utf-8")
     return (datetime.datetime.fromisoformat(dts))
-

--- a/src/hio/hioing.py
+++ b/src/hio/hioing.py
@@ -21,7 +21,7 @@ class Mixin():
     """
     Base class to enable consistent MRO for mixin multiple inheritance
     Allows each subclass to call
-    super(MixinSubClass, self).__init__(*pa, **kwa)
+    ``super(MixinSubClass, self).__init__(*pa, **kwa)``
     So the __init__ propagates to common top of Tree
     https://medium.com/geekculture/cooperative-multiple-inheritance-in-python-practice-60e3ac5f91cc
     """
@@ -37,25 +37,17 @@ class HioError(Exception):
     """
 
 class SizeError(HioError):
-    """
-    Resource size related errors
-    Usage:
-        raise SizeError("error message")
-    """
+    """Resource size related errors. Usage: raise SizeError("error message")."""
 
 class ValidationError(HioError):
-    """
-    Validation related errors
-    Usage:
-        raise ValidationError("error message")
-    """
+    """Validation related errors. Usage: raise ValidationError("error message")."""
 
 
 class VersionError(ValidationError):
     """
     Bad or Unsupported Version
 
-    Usage:
+    Usage::
         raise VersionError("error message")
     """
 
@@ -63,7 +55,7 @@ class OglerError(HioError):
     """
     Error using or configuring Ogler
 
-    Usage:
+    Usage::
         raise OglerError("error message")
     """
 
@@ -71,7 +63,7 @@ class FilerError(HioError):
     """
     Error using or configuring Filer
 
-    Usage:
+    Usage::
         raise FilerError("error message")
     """
 
@@ -79,7 +71,7 @@ class NamerError(HioError):
     """
     Error using or configuring Namer
 
-    Usage:
+    Usage::
         raise NamerError("error message")
     """
 
@@ -87,7 +79,7 @@ class MultiError(HioError):
     """
     Error using or configuring multiprocessing support classes
 
-    Usage:
+    Usage::
         raise MultiError("error message")
     """
 
@@ -95,7 +87,7 @@ class HierError(HioError):
     """
     Error using or configuring hiering support classes
 
-    Usage:
+    Usage::
         raise HierError("error message")
     """
 
@@ -103,7 +95,7 @@ class MemoerError(HioError):
     """
     Error using or configuring Memoer
 
-    Usage:
+    Usage::
         raise MemoGramError("error message")
     """
 
@@ -111,6 +103,6 @@ class MemoerVerifyError(MemoerError):
     """
     Error extracting and verifying memo gram signature
 
-    Usage:
+    Usage::
         raise MemoerSignatureError("error message")
     """


### PR DESCRIPTION
Fix RST/Sphinx docstring formatting warnings in `src/hio/help/decking.py`, `doming.py`, `ogling.py`, `timing.py`, and `src/hio/hioing.py`.

Changes:
- Normalize `Parameters::` / `Returns::` headings with required blank lines
- Fix literal block and block quote indentation issues

No logic or behavior changes — documentation only.