### PR TITLE
Docfmt: core module docstring formatting bundle

### DIFF
--- a/src/hio/core/memo/memoing.py
+++ b/src/hio/core/memo/memoing.py
@@ -201,7 +201,7 @@ The variables ghs, and ghns are fixed for given transport service type reliable
 or unreliable with head and neck fields defined appropriately
 The variables gs, gbs,and mms are derived from transport MTU size
 The desired gs for a given transport MTU instance may be smaller than the allowed
-maximum to accomodate buffers etc.
+maximum to accommodate buffers etc.
 Given the fixed gram head size for service type, ghs one can calculate the
 maximum memo size mms that includes the header overhead given the contraint of
 no more than 2**24-1 grams in a given memo due to 24 size of gram count gram num.
@@ -350,7 +350,7 @@ class Memoer(hioing.Mixin):
     On the receive side each complete memogram (gram) is put in a gram receive
     deque as a memogram (datagram sized) segment of a memo.
     These deques are indexed by the sender's source addr.
-    The grams in the gram recieve deque are then desegmented into a memo
+    The grams in the gram receive deque are then desegmented into a memo
     and placed in the memo deque for consumption by the application or some other
     higher level protocol.
 
@@ -363,10 +363,10 @@ class Memoer(hioing.Mixin):
     When using non-blocking IO, asynchronous datagram transport
     protocols may have hidden buffering constraints that result in fragmentation
     of the sent datagram which means the whole datagram is not sent at once via
-    a non-blocking send call. This means that the remainer of the datagram must
+    a non-blocking send call. This means that the remainder of the datagram must
     be sent later and may take multiple send calls to complete. The datagram
     protocol is responsible for managing the buffering and fragmentation but
-    depends on the sender repeated attempts to send the reaminder of the
+    depends on the sender repeated attempts to send the remainder of the
     full datagram. This is ensured with the final tier with a raw transmit
     buffer that waits until it is empty before attempting to send another
     gram. Because sending to different destinations may fail for different reasons
@@ -379,7 +379,7 @@ class Memoer(hioing.Mixin):
     serialization of the header (qb2 or qb64). This is more efficient and since
     gram headers will be stripped and discarded there is no need to archive them.
     The encapsulated unpartitioned memogram with its signature it what is meant
-    for archivel not the partitioned gram and per gram signature.
+    for archival not the partitioned gram and per gram signature.
 
     Inherited Class Attributes::
 
@@ -1367,12 +1367,12 @@ class Memoer(hioing.Mixin):
 
 
     def receive(self, *, echoic=False) -> (bytes, str or tuple or None):
-        """Attemps to receive bytes from remote source.
+        """Attempts to receive bytes from remote source.
 
         May use echoic=True and .echos to mock a transport layer for testing
-        Puts sent gram into .echos so that .recieve can extract it when using
-        same Memoer to send and recieve to itself via its own .echos
-        When using different Memoers each for send and recieve then must
+        Puts sent gram into .echos so that .receive can extract it when using
+        same Memoer to send and receive to itself via its own .echos
+        When using different Memoers each for send and receive then must
         manually copy from sender Memoer .echos to Receiver Memoer .echos
 
         Must be overridden in subclass.
@@ -1765,12 +1765,12 @@ class Memoer(hioing.Mixin):
 
 
     def send(self, gram, dst, *, echoic=False) -> int:
-        """Attemps to send bytes in txbs to remote destination dst.
+        """Attempts to send bytes in txbs to remote destination dst.
 
         May use echoic=True and .echos to mock a transport layer for testing
-        Puts sent gram into .echos so that .recieve can extract it when using
-        same Memoer to send and recieve to itself via its own .echos
-        When using different Memoers each for send and recieve then must
+        Puts sent gram into .echos so that .receive can extract it when using
+        same Memoer to send and receive to itself via its own .echos
+        When using different Memoers each for send and receive then must
         manually copy from sender Memoer .echos to Receiver Memoer .echos
 
         Must be overridden in subclass.
@@ -1992,7 +1992,7 @@ def openMemoer(cls=None, name="test", **kwa):
 
     Parameters:
         cls (Class): instance of subclass instance
-        name (str): unique identifer of Memoer peer.
+        name (str): unique identifier of Memoer peer.
             Enables management of transport by name.
     Usage::
 
@@ -2253,7 +2253,7 @@ def openSM(cls=None, name="test", **kwa):
 
     Parameters:
         cls (Class): instance of subclass instance
-        name (str): unique identifer of Memoer peer.
+        name (str): unique identifier of Memoer peer.
             Enables management of transport by name.
     Usage::
 

--- a/src/hio/core/serial/serialing.py
+++ b/src/hio/core/serial/serialing.py
@@ -42,10 +42,10 @@ class Console():
         rxbs (bytearray): of received characters (bytes)
 
     Methods:
-        reopen ():  closes and reopens .fd, sets .opened
-        close ():   closes .fd unsets .opened
-        get (): returns chars including newline but no more than bs characters
-        put ():  puts characters
+        - reopen: closes and reopens .fd, sets .opened
+        - close: closes .fd and unsets .opened
+        - get: returns chars including newline but no more than bs characters
+        - put: puts characters
 
     Hidden:
         ._line is bytearray of line buffer

--- a/src/hio/core/tcp/serving.py
+++ b/src/hio/core/tcp/serving.py
@@ -209,19 +209,17 @@ class Server(Acceptor):
     See tyming.Tymee for inherited attributes, properties, and methods
 
     Inherited Attributes:
-        .ha is (host,port) duple (two tuple)
-               host = "" or "0.0.0.0" means listen on all interfaces
-        .eha is normalized (host, port) duple for incoming TLS connections
-                as external facing address for TLS context
-        .bs is buffer size
-        .ss is server listen socket for incoming accept requests
-        .axes is deque of accepte connection duples (ca, cs)
-        .opened is boolean, True if listen socket .ss opened. False otherwise
+        ha (tuple[str, int]): (host, port) duple; host = "" or "0.0.0.0" means listen on all interfaces
+        eha (tuple[str, int]): normalized external-facing (host, port) for TLS context
+        bs (int): buffer size
+        ss (socket.socket | None): server listen socket for incoming accept requests
+        axes (deque): accepted connection duples (ca, cs)
+        opened (bool): True if listen socket ss is open; False otherwise
 
     Attributes:
-        .tymeout is tymeout in seconds for connection refresh
-        .wl is WireLog instance if any
-        .ixes is dict of incoming connections indexed by remote (host, port) duple
+        tymeout (float): timeout in seconds for connection refresh
+        wl (WireLog | None): WireLog instance if any
+        ixes (dict): incoming connections indexed by remote (host, port) duple
     """
 
     Tymeout = 1.0  # tymeout in seconds virtual tyme
@@ -489,25 +487,23 @@ class ServerTls(Server):
     See tyming.Tymee for inherited attributes, properties, and methods
 
     Inherited Attributes:
-        .ha is (host,port) duple (two tuple)
-               host = "" or "0.0.0.0" means listen on all interfaces
-        .eha is normalized (host, port) duple for incoming TLS connections
-                as external facing address for TLS context
-        .bs is buffer size
-        .ss is server listen socket for incoming accept requests
-        .axes is deque of accepte connection duples (ca, cs)
-        .opened is boolean, True if listen socket .ss opened. False otherwise
-        .timeout is timeout in seconds for connection refresh
-        .wl is WireLog instance if any
-        .ixes is dict of incoming connections indexed by remote (host, port) duple
+        ha (tuple[str, int]): (host, port) duple; host = "" or "0.0.0.0" means listen on all interfaces
+        eha (tuple[str, int]): normalized external-facing (host, port) for TLS context
+        bs (int): buffer size
+        ss (socket.socket | None): server listen socket for incoming accept requests
+        axes (deque): accepted connection duples (ca, cs)
+        opened (bool): True if listen socket ss is open; False otherwise
+        timeout (float): timeout in seconds for connection refresh
+        wl (WireLog | None): WireLog instance if any
+        ixes (dict): incoming connections indexed by remote (host, port) duple
 
     Attributes:
-        .context is TLS context instance
-        .version is TLS version
-        .certify is boolean, True to client certify, False otherwise
-        .keypath is path to key file
-        .certpath is path to cert file
-        .cafilepath is path to ca file
+        context (ssl.SSLContext | None): TLS context instance
+        version (int | None): TLS version
+        certify (bool | None): True to require client cert verification
+        keypath (str | None): path to key file
+        certpath (str | None): path to cert file
+        cafilepath (str | None): path to CA file
     """
     def __init__(self,
                  context=None,

--- a/src/hio/core/udp/peermemoing.py
+++ b/src/hio/core/udp/peermemoing.py
@@ -20,13 +20,10 @@ class PeerMemoer(Peer, Memoer):
 
 
     Inherited Class Attributes:
-        (Peer)
         BufSize (int): used to set default buffer size for transport datagram buffers
         MaxGramSize (int): max gram bytes for this transport
 
-        (Memoer)
-        Version (Versionage): default version consisting of namedtuple of form
-            (major: int, minor: int)
+        Version (Versionage): default version namedtuple of form (major: int, minor: int)
         Codex (GramDex): dataclass ref to gram codex
         Codes (dict): maps codex names to codex values
         Names (dict): maps codex values to codex names
@@ -36,10 +33,8 @@ class PeerMemoer(Peer, Memoer):
         MaxGramCount (int): absolute max gram count
 
     Inherited Attributes:
-        (Peer)
-        name (str): unique identifier of peer for managment purposes
-        ha (tuple): host address of form (host,port) of type (str, int) of this
-                peer's socket address.
+        name (str): unique identifier of peer for management purposes
+        ha (tuple): host address of form (host,port) of type (str, int) of this peer's socket address.
 
         bc (int or None): count of transport buffers of MaxGramSize
         bs (int): buffer size
@@ -48,78 +43,66 @@ class PeerMemoer(Peer, Memoer):
         ls (socket.socket): local socket of this Peer
         opened (bool): True local socket is created and opened. False otherwise
 
-        bcast (bool): True enables sending to broadcast addresses from local socket
-                      False otherwise
+        bcast (bool): True enables sending to broadcast addresses from local socket; False otherwise
 
-        (Memoer)
         version (Versionage): version for this memoir instance consisting of
-                namedtuple of form (major: int, minor: int)
+            namedtuple of form (major: int, minor: int)
         rxgs (dict): keyed by mid (memoID) with value of dict where each
-                value dict holds grams from memo keyed by gram number.
-                Grams have been stripped of their headers.
-                The mid appears in every gram from the same memo.
+            value dict holds grams from memo keyed by gram number.
+            Grams have been stripped of their headers.
+            The mid appears in every gram from the same memo.
         sources (dict): keyed by mid (memoID) that holds the src for the memo.
             This enables reattaching src to fused memo in rxms deque tuple.
         counts (dict): keyed by mid (memoID) that holds the gram count from
             the first gram for the memo. This enables lookup of the gram count when
             fusing its grams.
         oids (dict[mid: (oid | None)]): keyed by mid that holds the origin ID str for
-                the memo indexed by its mid (memoID). This enables reattaching
-                the oid to memo when placing fused memo in rxms deque.
-                Vid is only present when signed header otherwise oid is None
+            the memo indexed by its mid (memoID). This enables reattaching
+            the oid to memo when placing fused memo in rxms deque.
+            Vid is only present when signed header otherwise oid is None
         rxms (deque): holding rx (receive) memo tuples desegmented from rxgs grams
-                each entry in deque is tuple of form:
-                (memo: str, src: str, oid: str) where:
-                memo is fused memo, src is source addr, oid is origin ID
+            each entry in deque is tuple of form:
+            (memo: str, src: str, oid: str) where:
+            memo is fused memo, src is source addr, oid is origin ID
         txms (deque): holding tx (transmit) memo tuples to be segmented into
-                txgs grams where each entry in deque is tuple of form
-                (memo: str, dst: str, oid: str | None)
-                memo is memo to be partitioned into gram
-                dst is dst addr for grams
-                oid is verification id when gram is to be signed or None otherwise
+            txgs grams where each entry in deque is tuple of form
+            (memo: str, dst: str, oid: str | None)
+            memo is memo to be partitioned into gram
+            dst is dst addr for grams
+            oid is verification id when gram is to be signed or None otherwise
         txgs (deque): grams to transmit, each entry is duple of form:
-                (gram: bytes, dst: str).
+            (gram: bytes, dst: str).
         txbs (tuple): current transmisstion duple of form:
             (gram: bytearray, dst: str). gram bytearray may hold untransmitted
             portion when Encodesdatagram is not able to be sent all at once so can
             keep trying. Nothing to send indicated by (bytearray(), None)
             for (gram, dst)
         echos (deque): holding echo receive duples for testing. Each duple of
-                       form: (gram: bytes, dst: str).
+            form: (gram: bytes, dst: str).
 
 
     Inherited Properties:
-        (Peer)
         host (str): element of .ha duple
         port (int): element of .ha duple
         path (tuple): .ha (host, port)  alias to match .uxd
 
-        (Memoer)
         code (bytes | None): gram code for gram header when rending for tx
-        curt (bool): True means when rending for tx encode header in base2
-                     False means when rending for tx encode header in base64
+        curt (bool): True means when rending for tx encode header in base2; False means when rending for tx encode header in base64
         size (int): gram size when rending for tx.
-            first gram size = over head size + neck size + body size.
-            other gram size = over head size + body size.
-            Min gram body size is one.
-            Gram size also limited by MaxGramSize and MaxGramCount relative to
-            MaxMemoSize.
-        verific (bool): True means any rx grams must be signed.
-                        False otherwise
-        echoic (bool): True means use .echos in .send and .receive to mock the
-                            transport layer for testing and debugging.
-                       False means do not use .echos
-                       Each entry in .echos is a duple of form:
-                           (gram: bytes, src: str)
-                       Default echo is duple that
-                           indicates nothing to receive of form (b'', None)
-                       When False may be overridden by a method parameter
-        keep (dict): labels are oids, values are Keyage instances
-                         named tuple of signature key pair:
-                         sigkey = private signing key
-                         verkey = public verifying key
-                        Keyage = namedtuple("Keyage", "sigkey verkey")
+        verific (bool): True means any rx grams must be signed; False otherwise
+        echoic (bool): True means use .echos in .send and .receive to mock transport.
+        keep (dict): labels are oids and values are Keyage instances.
         oid (str|None): own oid defaults used to lookup keys to sign on tx
+
+        Notes:
+                - size: first gram size = over head size + neck size + body size;
+                    subsequent grams use over head size + body size; gram body size is at
+                    least one and is limited by MaxGramSize and MaxGramCount relative to
+                    MaxMemoSize.
+                - echoic: each entry in .echos is (gram: bytes, src: str); default echo
+                    is (b'', None); when False it may be overridden by method parameter.
+                - keep: Keyage is namedtuple("Keyage", "sigkey verkey") with private
+                    signing key sigkey and public verifying key verkey.
 
     """
 
@@ -129,8 +112,9 @@ class PeerMemoer(Peer, Memoer):
         Inherited Parameters:
             bc (int | None): count of transport buffers of MaxGramSize
 
-            See memoing.Memoer for other inherited paramters
-            See Peer for other inherited paramters
+        See Also:
+            memoing.Memoer: other inherited parameters.
+            Peer: other inherited parameters.
 
 
         Parameters:
@@ -148,7 +132,7 @@ def openPM(cls=None, name="test", temp=True, reopen=True, **kwa):
 
     Parameters:
         cls (Class): instance of subclass instance
-        name (str): unique identifer of PeerMemoer peer.
+        name (str): unique identifier of PeerMemoer peer.
                     Enables management of transport by name.
                     Provides unique path part so can have many peers each at
                     different paths but in same directory.
@@ -158,6 +142,9 @@ def openPM(cls=None, name="test", temp=True, reopen=True, **kwa):
                        False not (re)open with this init but later
 
     See udping.Peer for other keyword parameter passthroughs
+
+    See Also:
+        udping.Peer: other keyword parameter passthroughs.
 
     Usage::
 

--- a/src/hio/core/udp/udping.py
+++ b/src/hio/core/udp/udping.py
@@ -37,7 +37,7 @@ class Peer(hioing.Mixin):
 
 
     Attributes:
-        name (str): unique identifier of peer for managment purposes
+        name (str): unique identifier of peer for management purposes
         ha (tuple): host address of form (host,port) of type (str, int) of this
                 peer's socket address.
 
@@ -287,7 +287,7 @@ def openPeer(cls=None, name="test", **kwa):
 
     Parameters:
         cls (Class): instance of subclass instance
-        name (str): unique identifer of peer. Enables management of Peer sockets
+        name (str): unique identifier of peer. Enables management of Peer sockets
                     by name.
     Usage:
         with openPeer() as peer0:

--- a/src/hio/core/uxd/peermemoing.py
+++ b/src/hio/core/uxd/peermemoing.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 from ... import help
 
 from ...base import doing
-from ..uxd import Peer
+from .uxding import Peer
 from ..memo import Memoer
 
 logger = help.ogler.getLogger()
@@ -38,8 +38,8 @@ class PeerMemoer(Peer, Memoer):
         Inherited Parameters:
             bc (int or None): count of transport buffers of MaxGramSize
 
-            See memoing.Memoer for other inherited paramters
-            See Peer for other inherited paramters
+            See memoing.Memoer for other inherited parameters
+            See Peer for other inherited parameters
 
 
         Parameters:
@@ -58,7 +58,7 @@ def openPM(cls=None, name="test", temp=True, reopen=True, clear=True,
 
     Parameters:
         cls (Class): instance of subclass instance
-        name (str): unique identifer of PeerMemoer peer.
+        name (str): unique identifier of PeerMemoer peer.
                     Enables management of transport by name.
                     Provides unique path part so can have many peers each at
                     different paths but in same directory.
@@ -69,7 +69,7 @@ def openPM(cls=None, name="test", temp=True, reopen=True, clear=True,
         clear (bool): True means remove directory upon close when reopening
                       False means do not remove directory upon close when reopening
         filed (bool): True means .path is file path not directory path
-                      False means .path is directiory path not file path
+                      False means .path is directory path not file path
         extensioned (bool): When not filed:
                             True means ensure .path ends with fext
                             False means do not ensure .path ends with fext

--- a/src/hio/core/uxd/uxding.py
+++ b/src/hio/core/uxd/uxding.py
@@ -32,10 +32,8 @@ class Peer(filing.Filer):
         HeadDirPath (str): default abs dir path head such as "/usr/local/var"
         TailDirPath (str): default rel dir path tail when using head
         CleanTailDirPath (str): default rel dir path tail when creating clean
-        AltHeadDirPath (str): default alt dir path head such as  "~"
-                              as fallback when desired head not permitted.
-        AltTailDirPath (str): default alt rel dir path tail as fallback
-                              when using alt head.
+        AltHeadDirPath (str): default alt dir path head such as "~" as fallback when desired head not permitted.
+        AltTailDirPath (str): default alt rel dir path tail as fallback when using alt head.
         AltCleanTailDirPath (str): default alt rel path tail when creating clean
         TempHeadDir (str): default temp abs dir path head such as "/tmp"
         TempPrefix (str): default rel dir path prefix when using temp head
@@ -57,17 +55,14 @@ class Peer(filing.Filer):
         headDirPath (str): head directory path
         path (str or None):  full directory or file path once created else None
         perm (int):  numeric os permissions for directory and/or file(s)
-        filed (bool): True means .path ends in file.
-                       False means .path ends in directory
+        filed (bool): True means .path ends in file; False means .path ends in directory
         mode (str): file open mode if filed
         fext (str): file extension if filed
         file (File or None): File instance when filed and created.
-        opened (bool): True means directory path, uxd file, and socket are
-                created and opened. False otherwise
+        opened (bool): True means directory path, uxd file, and socket are created and opened. False otherwise
 
     Attributes:
-        umask (int): unpermission mask for uxd file, usually octal 0o022
-                     .umask is applied after .perm is set if any
+        umask (int): permission mask for uxd file, usually octal 0o022; .umask is applied after .perm is set if any
         bc (int or None): count of transport buffers of MaxGramSize
         bs (int): buffer size of transport buffers. When .bc then .bs is calculated
             by multiplying, .bs = .bc * .MaxGramSize. When .bc is None then .bs
@@ -112,15 +107,17 @@ class Peer(filing.Filer):
             clear (bool): True means remove directory upon close when reopening
                           False means do not remove directory upon close when reopening
             filed (bool): True means .path is file path not directory path
-                          False means .path is directiory path not file path
+                          False means .path is directory path not file path
             extensioned (bool): When not filed:
                                 True means ensure .path ends with fext
                                 False means do not ensure .path ends with fext
-            See Filing.Filer for other inherited paramters
+
+        See Also:
+            filing.Filer: other inherited parameters.
 
 
         Parameters:
-            umask (int): unpermission mask for uxd file, usually octal 0o022
+            umask (int): permission mask for uxd file, usually octal 0o022
             bc (int | None): count of transport buffers of MaxGramSize
             bs (int | None): buffer size of transport buffers. When .bc is provided
                 then .bs is calculated by multiplying, .bs = .bc * .MaxGramSize.
@@ -148,10 +145,10 @@ class Peer(filing.Filer):
 
 
     def actualBufSizes(self):
-        """Returns:
-            sizes (tuple); duple of the form (int, int) of the (tx, rx)
-                actual socket send and receive buffer size
+        """Return actual socket send and receive buffer size.
 
+        Returns:
+            tuple: (tx, rx) actual socket send and receive buffer sizes.
         """
         if not self.ls:
             return (0, 0)
@@ -164,10 +161,10 @@ class Peer(filing.Filer):
         """Opens socket in non blocking mode.
 
         Returns:
-            result (bool): True of opened successfully. False otherwise
+            result (bool): True if opened successfully. False otherwise
 
-        if socket not closed properly, binding socket gets error
-            OSError: (48, 'Address already in use')
+        Notes:
+            If socket is not closed properly, binding may raise OSError: (48, 'Address already in use').
         """
         if len(self.path) > self.MaxUxdPathSize:
             self.close()
@@ -225,12 +222,14 @@ class Peer(filing.Filer):
         """Idempotently open socket by closing first if need be
 
         Returns:
-            result (bool): True of opened successfully. False otherwise
+            result (bool): True if opened successfully. False otherwise
 
         Inherited Parameters:
             clear (bool): True means remove directory and uxd file upon close
                           False means do not remove directory and uxd file upon close
-            See filing.Filer for other inherited parameters
+
+        See Also:
+            filing.Filer: other inherited parameters.
         """
         opened = super(Peer, self).reopen(clear=clear, **kwa)
         if not opened:
@@ -245,7 +244,9 @@ class Peer(filing.Filer):
         Inherited Parameters:
             clear (bool): True means remove directory/uxd file upon close
                           False means do not remove directory/uxd file upon close
-            See filing.Filer for other inherited parameters
+
+        See Also:
+            filing.Filer: other inherited parameters.
         """
         if self.ls:
             self.ls.close() #close socket
@@ -335,7 +336,7 @@ def openPeer(cls=None, name="test", temp=True, reopen=True, clear=True,
 
     Parameters:
         cls (Class): instance of subclass instance
-        name (str): unique identifer of peer. Unique path part so can have many
+        name (str): unique identifier of peer. Unique path part so can have many
             Peers each at different paths that each use different dirs or files
         temp (bool): True means open in temporary directory, clear on close
                      Otherwise open in persistent directory, do not clear on close
@@ -344,7 +345,7 @@ def openPeer(cls=None, name="test", temp=True, reopen=True, clear=True,
         clear (bool): True means remove directory upon close when reopening
                       False means do not remove directory upon close when reopening
         filed (bool): True means .path is file path not directory path
-                      False means .path is directiory path not file path
+                      False means .path is directory path not file path
         extensioned (bool): When not filed:
                             True means ensure .path ends with fext
                             False means do not ensure .path ends with fext

--- a/src/hio/core/wiring.py
+++ b/src/hio/core/wiring.py
@@ -54,30 +54,29 @@ class WireLog():
     buffers for logging 'over the wire' network tx and rx packets as bytes
 
     Attributes:
-        .rxed is Boolean True means log rx
-        .txed is Boolean True means log tx
-        .samed is Boolean True means log both rx and tx to same file or buffer
-        .filed is Boolean True means log to file False means log to memory buffer
-        .fmt is io write bytes printf style format string
+        rxed (bool): True means log rx
+        txed (bool): True means log tx
+        samed (bool): True means log both rx and tx to same file or buffer
+        filed (bool): True means log to file; False means log to memory buffer
+        fmt (bytes): io write bytes printf style format string
             Default is::
 
                 b"\\n%(dx)b %(who)b:\\n%(data)b\\n"
 
-            where:
-                who is src or dst for rx tx respectively
-                dx is the io direction and will be set to either b'tx' or b'rx' and
-                data is the actual io data as bytes
-            to write io data without direction who or line feeds use fmt= b'%(data)b'
-        .name is str used in file name
-        .temp is Boolean True means use /tmp directory
-        .prefix is str used as part of path prefix and formating
-        .headDirPath is str used as head of path
-        .tailDirpath is str used as tail of path
-        .altTailDirPath is str used a alternate tail of path
-        .dirPath is full directory path
-        .rxl is rx log io file or io buffer
-        .txl is tx log io file or io buffer
-        .opened is Boolean, True means file is opened Otherwise False
+            Placeholder semantics: ``who`` is src or dst for rx/tx,
+            ``dx`` is the io direction (b'tx' or b'rx'), and ``data`` is
+            the actual io payload bytes. To write data without direction,
+            who, or line feeds, use ``fmt=b'%(data)b'``.
+        name (str): used in file name
+        temp (bool): True means use /tmp directory
+        prefix (str): used as part of path prefix and formatting
+        headDirPath (str): used as head of path
+        tailDirPath (str): used as tail of path
+        altTailDirPath (str): alternate tail of path
+        dirPath (str): full directory path
+        rxl (io.IOBase | io.BytesIO | None): rx log file or memory buffer
+        txl (io.IOBase | io.BytesIO | None): tx log file or memory buffer
+        opened (bool): True means file/buffer is opened; False otherwise
 
     """
     Prefix = "hio"

--- a/src/hio/core/wms/wmsing.py
+++ b/src/hio/core/wms/wmsing.py
@@ -30,7 +30,7 @@ class Peer(filing.Filer):
     """Class to manage reliable datagram transport on Windows using Mailslots
     instead of unix domain sockets. WinMailSlot (wms)
 
-    Because win-mail-slots (wms) are reliable no need for retry tymer.
+    Because win-mail-slots (wms) are reliable no need for retry timer.
     Because win-mail-slots do not attach the source address we have to
     embed the source address in the memogram header. So we need a new memogram
     header code for wms as reliable transport replacement for uxd on Windows.
@@ -41,10 +41,8 @@ class Peer(filing.Filer):
         HeadDirPath (str): default abs dir path head such as "/usr/local/var"
         TailDirPath (str): default rel dir path tail when using head
         CleanTailDirPath (str): default rel dir path tail when creating clean
-        AltHeadDirPath (str): default alt dir path head such as  "~"
-                              as fallback when desired head not permitted.
-        AltTailDirPath (str): default alt rel dir path tail as fallback
-                              when using alt head.
+        AltHeadDirPath (str): default alt dir path head such as "~" as fallback when desired head not permitted.
+        AltTailDirPath (str): default alt rel dir path tail as fallback when using alt head.
         AltCleanTailDirPath (str): default alt rel path tail when creating clean
         TempHeadDir (str): default temp abs dir path head such as "/tmp"
         TempPrefix (str): default rel dir path prefix when using temp head
@@ -60,13 +58,11 @@ class Peer(filing.Filer):
         headDirPath (str): head directory path
         path (str or None):  full directory or file path once created else None
         perm (int):  numeric os permissions for directory and/or file(s)
-        filed (bool): True means .path ends in file.
-                       False means .path ends in directory
+        filed (bool): True means .path ends in file; False means .path ends in directory.
         mode (str): file open mode if filed
         fext (str): file extension if filed
         file (File or None): File instance when filed and created.
-        opened (bool): True means directory path, uxd file, and socket are
-                created and opened. False otherwise
+        opened (bool): True means directory path, uxd file, and socket are created and opened; False otherwise.
 
     Class Attributes:
         Umask (int): octal default umask permissions such as 0o022
@@ -75,12 +71,12 @@ class Peer(filing.Filer):
 
 
     Attributes:
-        umask (int): unpermission mask for uxd file, usually octal 0o022
-                     .umask is applied after .perm is set if any
+        umask (int): permission mask for uxd file, usually octal 0o022;
+            .umask is applied after .perm is set if any.
         bc (int or None): count of transport buffers of MaxGramSize
-        bs (int): buffer size of transport buffers. When .bc then .bs is calculated
-            by multiplying, .bs = .bc * .MaxGramSize. When .bc is None then .bs
-            is provided value or default .BufSize
+        bs (int): buffer size of transport buffers. When .bc then .bs is
+            calculated by multiplying (.bs = .bc * .MaxGramSize). When .bc is
+            None then .bs is provided value or default .BufSize.
         wl (WireLog): instance ref for debug logging of over the wire tx and rx
         ls (socket.socket): local slot of this Peer
 
@@ -109,20 +105,22 @@ class Peer(filing.Filer):
         """Initialization method for instance.
 
         Inherited Parameters:
-            reopen (bool): True (re)open with this init
-                           False not (re)open with this init but later (default)
-            clear (bool): True means remove directory upon close when reopening
-                          False means do not remove directory upon close when reopening
-            filed (bool): True means .path is file path not directory path
-                          False means .path is directiory path not file path
+            reopen (bool): True (re)open with this init. False means do not
+                (re)open with this init but later (default).
+            clear (bool): True means remove directory upon close when reopening;
+                False means do not remove directory upon close when reopening.
+            filed (bool): True means .path is file path not directory path;
+                False means .path is directory path not file path.
             extensioned (bool): When not filed:
-                                True means ensure .path ends with fext
-                                False means do not ensure .path ends with fext
-            See Filing.Filer for other inherited paramters
+                True means ensure .path ends with fext.
+                False means do not ensure .path ends with fext.
+
+        See Also:
+            Filing.Filer: other inherited parameters.
 
 
         Parameters:
-            umask (int): unpermission mask for uxd file, usually octal 0o022
+            umask (int): permission mask for uxd file, usually octal 0o022
             bc (int | None): count of transport buffers of MaxGramSize
             bs (int | None): buffer size of transport buffers. When .bc is provided
                 then .bs is calculated by multiplying, .bs = .bc * .MaxGramSize.
@@ -185,11 +183,12 @@ class Peer(filing.Filer):
         """
         Perform a non-blocking read on the mailslot
 
-        Returns tuple of form (data, sa)
-        if no data, returns ('', None)
-          but always returns a tuple with 2 elements
+        Returns:
+            tuple: (data, sa). If no data, returns (b'', None), but always
+            returns a tuple with 2 elements.
 
-        Note win32file.ReadFile returns a tuple: (errcode, data)
+        Notes:
+            win32file.ReadFile returns a tuple: (errcode, data).
 
         """
         try:
@@ -216,7 +215,7 @@ class Peer(filing.Filer):
         """
         Perform a non-blocking write on the mailslot
         data is string in python2 and bytes in python3
-        da is destination mailslot path
+        dest is destination mailslot path
 
         Parameters:
             data (bytes): to send


### PR DESCRIPTION
## Summary
Conservative docstring-format cleanup across core modules.

## Files
- `src/hio/core/memo/memoing.py`
- `src/hio/core/serial/serialing.py`
- `src/hio/core/tcp/serving.py`
- `src/hio/core/udp/peermemoing.py`
- `src/hio/core/udp/udping.py`
- `src/hio/core/uxd/peermemoing.py`
- `src/hio/core/uxd/uxding.py`
- `src/hio/core/wiring.py`
- `src/hio/core/wms/wmsing.py`

## Scope
- Docstring structure/list formatting normalization
- No behavior changes

## Validation
- Sphinx docs build clean
- Focused core tests pass