### PR TITLE
Docs: reduce duplicate indexing noise and preserve API pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,9 @@ Version 0.7.2
 - Added support for multiprocessing via multidoing.py
 
 Version 0.4.1
-- Refined Doist and DoDoer makes their protocol interfaces nearly identical as
-  is reasonably practical
+- Refined Doist and DoDoer makes their protocol interfaces nearly identical as is reasonably practical
 - Added HTTP support with hio compatible HTTP Client and HTTP WSGI Server
-- Example test code shows HTTP Server working with Falcon and Bottle ReST Micro
-  frameworks
+- Example test code shows HTTP Server working with Falcon and Bottle ReST Micro frameworks
 
 
 Version 0.3.4

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,19 +36,22 @@ version = release
 extensions = [
               'myst_parser',
               'sphinx.ext.napoleon',
-              'sphinx.ext.viewcode',
               'sphinx.ext.autosummary',
               'sphinx.ext.autodoc',
               'autoapi.extension',
               "sphinx_rtd_theme",
               ]
 
+# Work around a Sphinx viewcode crash on Python 3.14 during collect_pages.
+# Keep viewcode enabled on earlier Python versions.
+if sys.version_info < (3, 14):
+    extensions.append('sphinx.ext.viewcode')
+
 napoleon_include_init_with_doc = True
 
-autoapi_dirs = [os.path.abspath('./../../src/hio/base')]
+autoapi_dirs = [os.path.abspath('./../../src/hio')]
 autoapi_options = [
     "members",
-    "undoc-members",
     "show-inheritance",
     "noindex",
 ]
@@ -66,7 +69,7 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'test.md']
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/source/hio.core.rst
+++ b/docs/source/hio.core.rst
@@ -21,6 +21,7 @@ hio.core.coring module
    :members:
    :undoc-members:
    :show-inheritance:
+   :no-index:
 
 hio.core.wiring module
 ----------------------
@@ -29,6 +30,7 @@ hio.core.wiring module
    :members:
    :undoc-members:
    :show-inheritance:
+   :no-index:
 
 Module contents
 ---------------
@@ -37,3 +39,4 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
+   :no-index:

--- a/docs/source/hio.core.serial.rst
+++ b/docs/source/hio.core.serial.rst
@@ -11,6 +11,7 @@ hio.core.serial.serialing module
    :members:
    :undoc-members:
    :show-inheritance:
+   :no-index:
 
 Module contents
 ---------------
@@ -19,3 +20,4 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
+   :no-index:

--- a/docs/source/hio.core.tcp.rst
+++ b/docs/source/hio.core.tcp.rst
@@ -11,6 +11,7 @@ hio.core.tcp.clienting module
    :members:
    :undoc-members:
    :show-inheritance:
+   :no-index:
 
 hio.core.tcp.serving module
 ---------------------------
@@ -19,6 +20,7 @@ hio.core.tcp.serving module
    :members:
    :undoc-members:
    :show-inheritance:
+   :no-index:
 
 hio.core.tcp.tcping module
 --------------------------
@@ -27,6 +29,7 @@ hio.core.tcp.tcping module
    :members:
    :undoc-members:
    :show-inheritance:
+   :no-index:
 
 Module contents
 ---------------
@@ -35,3 +38,4 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
+   :no-index:

--- a/docs/source/hio.core.udp.rst
+++ b/docs/source/hio.core.udp.rst
@@ -11,6 +11,7 @@ hio.core.udp.udping module
    :members:
    :undoc-members:
    :show-inheritance:
+   :no-index:
 
 Module contents
 ---------------
@@ -19,3 +20,4 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
+   :no-index:

--- a/docs/source/hio.demo.rst
+++ b/docs/source/hio.demo.rst
@@ -8,3 +8,4 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
+   :no-index:

--- a/docs/source/hio.help.rst
+++ b/docs/source/hio.help.rst
@@ -11,6 +11,7 @@ hio.help.helping module
    :members:
    :undoc-members:
    :show-inheritance:
+   :no-index:
 
 hio.help.ogling module
 ----------------------
@@ -19,6 +20,7 @@ hio.help.ogling module
    :members:
    :undoc-members:
    :show-inheritance:
+   :no-index:
 
 hio.help.timing module
 ----------------------
@@ -27,6 +29,7 @@ hio.help.timing module
    :members:
    :undoc-members:
    :show-inheritance:
+   :no-index:
 
 Module contents
 ---------------
@@ -35,3 +38,4 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
+   :no-index:

--- a/docs/source/hio.rst
+++ b/docs/source/hio.rst
@@ -22,6 +22,7 @@ hio.cli module
    :members:
    :undoc-members:
    :show-inheritance:
+   :no-index:
 
 hio.daemon module
 -----------------
@@ -30,6 +31,7 @@ hio.daemon module
    :members:
    :undoc-members:
    :show-inheritance:
+   :no-index:
 
 hio.hioing module
 -----------------
@@ -38,6 +40,7 @@ hio.hioing module
    :members:
    :undoc-members:
    :show-inheritance:
+   :no-index:
 
 Module contents
 ---------------
@@ -46,3 +49,4 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
+   :no-index:


### PR DESCRIPTION
## Summary
Docs configuration/indexing cleanup to reduce duplicate object noise while preserving content visibility.

## Files
- `README.md`
- `docs/source/conf.py`
- `docs/source/hio.core.rst`
- `docs/source/hio.core.serial.rst`
- `docs/source/hio.core.tcp.rst`
- `docs/source/hio.core.udp.rst`
- `docs/source/hio.demo.rst`
- `docs/source/hio.help.rst`
- `docs/source/hio.rst`

## Scope
- Conservative docs config/page indexing adjustments
- No runtime code changes

## Validation
- Sphinx docs build clean