### PR TITLE
Webduror

### DIFF
--- a/.github/workflows/wasm-ci.yml
+++ b/.github/workflows/wasm-ci.yml
@@ -2,7 +2,7 @@ name: WASM Tests
 
 on:
   push:
-    branches: ['master']
+    branches: ['main']
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/wasm-ci.yml
+++ b/.github/workflows/wasm-ci.yml
@@ -1,0 +1,42 @@
+name: WASM Tests
+
+on:
+  push:
+    branches: ['master']
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  wasm-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        runtime: [chrome, firefox, node]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '>=3.14.2'
+      - uses: pyodide/pyodide-actions/install-browser@v2
+        with:
+          runner: playwright
+          browser: ${{ matrix.runtime }}
+      - uses: pyodide/pyodide-actions/download-pyodide@v2
+        with:
+          version: 314.0.1
+          to: dist
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest-pyodide playwright
+          python -m playwright install --with-deps
+      - name: Run WebDuror WASM tests in Pyodide
+        env:
+          RUN_WASM_TESTS: "true"
+        run: |
+          pytest tests/wasm/test_webduring_wasm.py \
+            --confcutdir=tests/wasm \
+            --runtime ${{ matrix.runtime }} \
+            --dist-dir=./dist/ \
+            -v

--- a/.github/workflows/wasm-ci.yml
+++ b/.github/workflows/wasm-ci.yml
@@ -29,8 +29,11 @@ jobs:
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest-pyodide playwright
+          pip install pytest-pyodide playwright wheel
           python -m playwright install --with-deps
+      - name: Build HIO wheel
+        run: |
+          python setup.py bdist_wheel --dist-dir dist
       - name: Run WebDuror WASM tests in Pyodide
         env:
           RUN_WASM_TESTS: "true"

--- a/.github/workflows/wasm-ci.yml
+++ b/.github/workflows/wasm-ci.yml
@@ -28,8 +28,8 @@ jobs:
           to: dist
       - name: Install test dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install pytest-pyodide playwright wheel
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install pytest-pyodide playwright
           python -m playwright install --with-deps
       - name: Build HIO wheel
         run: |

--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ setup(
         'multidict>=6.7.0',
         'falcon>=4.2.0',
         'ordered-set>=4.1.0',
+        'sortedcontainers>=2.4.0',
         'pysodium>=0.7.18',
         'blake3>=1.0.8',
     ],

--- a/src/hio/base/__init__.py
+++ b/src/hio/base/__init__.py
@@ -10,6 +10,37 @@ from .doing import Doist, doize, doify, Doer, DoDoer
 from .filing import openFiler, Filer, FilerDoer
 from .webduring import WebSubDb, WebDuror, openWebDuror
 
+__all__ = (
+    "Tymist",
+    "Tymee",
+    "Tymer",
+    "Doist",
+    "doize",
+    "doify",
+    "Doer",
+    "DoDoer",
+    "openFiler",
+    "Filer",
+    "FilerDoer",
+    "WebSubDb",
+    "WebDuror",
+    "openWebDuror",
+    "Duror",
+    "openDuror",
+    "SuberBase",
+    "Suber",
+    "IoSuber",
+    "IoSetSuber",
+    "DomSuberBase",
+    "DomSuber",
+    "DomIoSuber",
+    "DomIoSetSuber",
+    "Subery",
+    "Bosser",
+    "Crewer",
+    "TagDex",
+)
+
 
 _DURING_EXPORTS = (
     "Duror",

--- a/src/hio/base/__init__.py
+++ b/src/hio/base/__init__.py
@@ -3,9 +3,54 @@
 hio.base Package
 """
 
+import importlib
+
 from .tyming import Tymist, Tymee, Tymer
 from .doing import Doist, doize, doify, Doer, DoDoer
 from .filing import openFiler, Filer, FilerDoer
-from .multidoing import Bosser, Crewer, TagDex
-from .during import (Duror, openDuror, SuberBase, Suber, IoSuber, IoSetSuber,
-                     DomSuberBase, DomSuber, DomIoSuber, DomIoSetSuber, Subery)
+from .webduring import WebSubDb, WebDuror, openWebDuror
+
+
+_DURING_EXPORTS = (
+    "Duror",
+    "openDuror",
+    "SuberBase",
+    "Suber",
+    "IoSuber",
+    "IoSetSuber",
+    "DomSuberBase",
+    "DomSuber",
+    "DomIoSuber",
+    "DomIoSetSuber",
+    "Subery",
+)
+
+_MULTIDOING_EXPORTS = (
+    "Bosser",
+    "Crewer",
+    "TagDex",
+)
+
+# When during or multidoing is imported, import it at runtime so lmdb is not
+# loaded when running in wasm. This imports the module/function, caches it,
+# and returns it.
+def __getattr__(name):
+    if name == "during" or name in _DURING_EXPORTS:
+        module = importlib.import_module(".during", __name__)
+        globals()["during"] = module
+        if name == "during":
+            return module
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+
+    if name == "multidoing" or name in _MULTIDOING_EXPORTS:
+        module = importlib.import_module(".multidoing", __name__)
+        globals()["multidoing"] = module
+        if name == "multidoing":
+            return module
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/hio/base/hier/boxing.py
+++ b/src/hio/base/hier/boxing.py
@@ -14,7 +14,6 @@ from typing import Type
 
 from ..tyming import Tymee
 from ..doing import Doer
-from ..during import Subery
 from ...hioing import Mixin, HierError
 from .hiering import Nabes, WorkDom
 from .holding import Hold
@@ -737,6 +736,8 @@ class Boxer(Tymee):
         fun = fun if fun is not None else self.fun
         durable = durable if durable is not None else self.durable
         if durable:
+            from ..during import Subery
+
             if self.hold.subery and not self.hold.subery.opened:
                 self.hold.subery.reopen(temp=temp)
             else:

--- a/src/hio/base/hier/canning.py
+++ b/src/hio/base/hier/canning.py
@@ -7,11 +7,14 @@ Provides durable dom support for items in Hold
 from __future__ import annotations  # so type hints of classes get resolved later
 
 from collections.abc import Mapping
-from typing import Any, Type, ClassVar
+from typing import Any, Type, ClassVar, TYPE_CHECKING
 from dataclasses import dataclass, astuple, asdict, field, fields, InitVar
 
 from ...help import NonStringIterable, namify, registerify, TymeDom
 from ...hioing import HierError
+
+if TYPE_CHECKING:
+    from ..during import DomSuber
 
 
 @namify

--- a/src/hio/base/hier/canning.py
+++ b/src/hio/base/hier/canning.py
@@ -12,7 +12,6 @@ from dataclasses import dataclass, astuple, asdict, field, fields, InitVar
 
 from ...help import NonStringIterable, namify, registerify, TymeDom
 from ...hioing import HierError
-from ..during import DomSuber
 
 
 @namify

--- a/src/hio/base/hier/holding.py
+++ b/src/hio/base/hier/holding.py
@@ -14,7 +14,6 @@ from collections.abc import Mapping
 from contextlib import contextmanager
 from typing import Any
 
-import lmdb
 from ordered_set import OrderedSet as oset
 
 from hio import HierError

--- a/src/hio/base/webduring.py
+++ b/src/hio/base/webduring.py
@@ -175,7 +175,11 @@ class WebDuror(Filer):
         return self.opened
 
     def close(self, clear=False):
-        """Close local handles and clear in-memory store state."""
+        """Close local handles and clear in-memory store state.
+
+        Use await flush() or await aclose() to persist pending writes.
+        Use await aclose(clear=True) to clear persisted browser storage.
+        """
         self.env = None
         self.opened = False
         self._stores = {}

--- a/src/hio/base/webduring.py
+++ b/src/hio/base/webduring.py
@@ -1,0 +1,802 @@
+# -*- encoding: utf-8 -*-
+"""Browser-safe durable storage for HIO wrappers."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+import json
+
+from ordered_set import OrderedSet as oset
+from sortedcontainers import SortedDict
+
+import hio
+
+from hio import HierError
+from .filing import Filer
+
+try:
+    from pyscript import storage
+except ImportError:  # pragma: no cover
+    storage = None
+
+
+_RECORDS_KEY = "__records__"
+
+
+def _to_bytes(value):
+    if isinstance(value, memoryview):
+        return bytes(value)
+    if hasattr(value, "encode"):
+        return value.encode("utf-8")
+    return bytes(value)
+
+
+class WebSubDb:
+    """LMDB-like sub-database handle for existing wrapper classes."""
+
+    def __init__(self, *, key, dupsort, items):
+        self.key = _to_bytes(key)
+        self.dupsort = True if dupsort else False
+        self.items = items
+
+    def flags(self):
+        return {"dupsort": self.dupsort}
+
+
+class WebDuror(Filer):
+    """Browser durable storage with Duror-compatible method semantics.
+
+    Uses an async PyScript style storage opener instead of LMDB and exposes the
+    same low-level db methods used by Duror wrappers.
+    """
+
+    SuffixSize = 32
+    MaxSuffix = int("f" * SuffixSize, 16)
+    MetaStore = b"__meta__"
+    VersionKey = b"__version__"
+
+    def __init__(
+        self,
+        *,
+        name="main",
+        base="",
+        temp=False,
+        reopen=False,
+        clear=False,
+        stores=None,
+        storageOpener=None,
+        **kwa,
+    ):
+        """Setup browser durable storage state.
+
+        Parameters:
+            stores (Iterable[bytes|str]): sub-database names to open.
+            storageOpener (Callable): async opener for a named browser storage namespace.
+        """
+        if kwa:
+            raise HierError(f"Unsupported WebDuror parameters: {', '.join(kwa)}")
+        super(WebDuror, self).__init__(
+            name=name,
+            base=base,
+            temp=temp,
+            reopen=False,
+            clear=clear,
+        )
+        self.env = None
+        self._version = None
+        self._stores = {}
+        self._handles = {}
+        self._dirty = set()
+        self._store_names = () if stores is None else tuple(_to_bytes(store) for store in stores)
+        self._storageOpener = storageOpener
+
+        if reopen:
+            raise HierError("WebDuror uses async open; use await reopen() or openWebDuror().")
+
+    def open_db(self, key=None, dupsort=False):
+        if not self.opened or self.env is None:
+            raise HierError("WebDuror is not open.")
+        store = self.MetaStore if key is None else _to_bytes(key)
+        if store not in self._stores:
+            raise HierError(f"WebDuror store {store!r} was not declared before open.")
+
+        return WebSubDb(
+            key=store,
+            dupsort=dupsort,
+            items=self._stores[store],
+        )
+
+    async def reopen(
+        self,
+        *,
+        clear=False,
+        stores=None,
+        storageOpener=None,
+        temp=None,
+        **kwa,
+    ):
+        """Open declared browser storage namespaces and load persisted records."""
+        if kwa:
+            raise HierError(f"Unsupported WebDuror reopen parameters: {', '.join(kwa)}")
+        if stores is not None:
+            self._store_names = tuple(_to_bytes(store) for store in stores)
+        if storageOpener is not None:
+            self._storageOpener = storageOpener
+        if temp is not None:
+            self.temp = True if temp else False
+
+        if self.opened:
+            await self.aclose(clear=clear)
+
+        opener = self._storageOpener if self._storageOpener is not None else storage
+        if opener is None:
+            raise HierError("WebDuror requires pyscript.storage or storageOpener.")
+
+        declared = (self.MetaStore,) + tuple(store for store in self._store_names if store != self.MetaStore)
+        handles = {}
+        loaded = {}
+        for store in declared:
+            name = store.decode("utf-8")
+            namespace = f"{self.base}:{self.name}:{name}" if self.base else f"{self.name}:{name}"
+            handle = await opener(namespace)
+            if clear:
+                handle[_RECORDS_KEY] = "{}"
+                await handle.sync()
+            raw = handle.get(_RECORDS_KEY)
+            if raw in (None, ""):
+                records = {}
+            else:
+                if isinstance(raw, (bytes, memoryview)):
+                    raw = bytes(raw).decode("utf-8")
+                if isinstance(raw, str):
+                    payload = json.loads(raw)
+                elif isinstance(raw, dict):
+                    payload = raw
+                else:
+                    raise TypeError(f"Unsupported persisted record payload type: {type(raw)}")
+                records = {
+                    bytes.fromhex(str(key)): bytes.fromhex(str(val))
+                    for key, val in payload.items()
+                }
+            handles[store] = handle
+            loaded[store] = SortedDict(records)
+
+        self._stores = loaded
+        self._handles = handles
+        self._dirty = set()
+        self.env = self
+        self.opened = True
+        self._version = None
+
+        if self.getVer() is None:
+            self.version = hio.__version__
+            await self.flush()
+
+        return self.opened
+
+    def close(self, clear=False):
+        """Close local handles and clear in-memory store state."""
+        self.env = None
+        self.opened = False
+        self._stores = {}
+        self._handles = {}
+        self._dirty = set()
+        self._version = None
+        return not self.opened
+
+    async def aclose(self, clear=False):
+        """Flush pending writes, optionally clear persisted browser records, and close."""
+        if self.opened and self._dirty and not clear:
+            await self.flush()
+        if self.opened and clear:
+            for handle in self._handles.values():
+                handle[_RECORDS_KEY] = "{}"
+                await handle.sync()
+        self.close()
+        return self.opened
+
+    async def flush(self):
+        """Persist dirty stores through their browser storage handles."""
+        if not self._dirty:
+            return 0
+        if not self.opened:
+            raise HierError("WebDuror is not open.")
+        count = 0
+        for store in tuple(self._stores):
+            if store not in self._dirty:
+                continue
+            self._handles[store][_RECORDS_KEY] = json.dumps(
+                {key.hex(): val.hex() for key, val in self._stores[store].items()},
+                sort_keys=True,
+            )
+            await self._handles[store].sync()
+            self._dirty.remove(store)
+            count += 1
+        return count
+
+    @property
+    def version(self):
+        """ Return the version of database stored in __version__ key.
+
+        This value is read through cached in memory
+
+        Returns:
+            version (str): semver string
+                the version of the database or None if not set in the database
+
+        """
+        if self._version is None:
+            self._version = self.getVer()
+        return self._version
+
+    @version.setter
+    def version(self, version):
+        """Set the version of the database in memory and in the __version__ key
+
+        Parameters:
+            version (str): The new semver formatted version of the database
+
+        """
+        if hasattr(version, "decode"):
+            version = version.decode("utf-8")
+        self._version = version
+        self.setVer(version)
+
+    def getVer(self):
+        """Returns the value of the the semver formatted version in the
+        __version__ key in this database
+
+        Returns:
+            str: semver formatted version of the database
+
+        """
+        val = self._stores[self.MetaStore].get(self.VersionKey)
+        return val.decode("utf-8") if val is not None else None
+
+    def setVer(self, version):
+        """ Set the version of the database in the __version__ key
+
+        Parameters:
+            version (str): The new semver formatted version str of the database
+
+        """
+        self._stores[self.MetaStore][self.VersionKey] = _to_bytes(version)
+        self._dirty.add(self.MetaStore)
+
+    def putVal(self, sdb, key, val):
+        """Write serialized bytes val to location key in db (subdb)
+        Does not overwrite.
+        Returns:
+            result (bool): True if val successfully written; False if val at key already exists
+
+        Parameters:
+            sdb (WebSubDb): opened named subdb with dupsort=False
+            key (bytes): within subdb's keyspace
+            val (bytes):  to be written at key
+        """
+        key = _to_bytes(key)
+        if key in sdb.items:
+            return False
+        sdb.items[key] = _to_bytes(val)
+        self._dirty.add(sdb.key)
+        return True
+
+    def pinVal(self, sdb, key, val):
+        """Write serialized bytes val to location key in db
+        Overwrites existing val if any
+        Returns:
+            result (bool): True if val successfully written; False otherwise
+
+        Parameters:
+            sdb (WebSubDb): opened named subdb with dupsort=False
+            key (bytes): within subdb's keyspace
+            val (bytes):  to be written at key
+        """
+        sdb.items[_to_bytes(key)] = _to_bytes(val)
+        self._dirty.add(sdb.key)
+        return True
+
+    def getVal(self, sdb, key):
+        """Get val at key in db
+
+        Returns:
+            val (bytes):  None if no entry at key
+
+        Parameters:
+            sdb (WebSubDb): opened named subdb with dupsort=False
+            key (bytes): within subdb's keyspace
+
+        """
+        val = sdb.items.get(_to_bytes(key))
+        return bytes(val) if val is not None else None
+
+    def remVal(self, sdb, key):
+        """Removes value at key in db.
+
+        Returns:
+            result (bool): True If key exists in database
+                           False otherwise
+
+        Parameters:
+            sdb (WebSubDb): opened named subdb with dupsort=False
+            key (bytes): within subdb's keyspace
+        """
+        key = _to_bytes(key)
+        if key not in sdb.items:
+            return False
+        del sdb.items[key]
+        self._dirty.add(sdb.key)
+        return True
+
+    def cntVals(self, sdb):
+        """Counts entries in subdb db
+
+        Returns:
+            count (int): number of entries in subdb db, or zero otherwise
+
+        Parameters:
+            sdb (WebSubDb): opened named subdb with dupsort=False
+        """
+        return len(sdb.items)
+
+    def getTopItemIter(self, sdb, top=b""):
+        """Iterates over branch of subdb db rooted at top key
+
+        Returns:
+            items (Iterator): of (full key, val) tuples over a branch of the db
+                given by top key where: full key is full database key for val
+                not truncated top key
+
+        Raises StopIteration Error when empty.
+
+        Parameters:
+            sdb (WebSubDb): instance of named sub db with dupsort==False
+            top (bytes): truncated top key, a key space prefix to get all the items
+                        from multiple branches of the key space. If top key is
+                        empty then gets all items in database.
+                        In Python str.startswith('') always returns True so if branch
+                        key is empty string it matches all keys in db with startswith.
+        """
+        top = _to_bytes(top)
+        for key in sdb.items.irange(minimum=top):
+            if not key.startswith(top):
+                break
+            yield (bytes(key), bytes(sdb.items[key]))
+
+    def remTopVals(self, sdb, top=b""):
+        """Removes all values in branch of db given top key.
+
+        Returns:
+            result (bool): True if values were deleted at key.
+                           False otherwise if no values at key
+
+        Parameters:
+            sdb (WebSubDb): instance of named sub db with dupsort==False
+            top (bytes): truncated top key, a key space prefix to get all the items
+                        from multiple branches of the key space. If top key is
+                        empty then deletes all items in database
+
+        Raises StopIteration Error when empty.
+
+        """
+        top = _to_bytes(top)
+        keys = []
+        for key in sdb.items.irange(minimum=top):
+            if not key.startswith(top):
+                break
+            keys.append(key)
+        for key in keys:
+            del sdb.items[key]
+        if keys:
+            self._dirty.add(sdb.key)
+        return True if keys else False
+
+    @staticmethod
+    def suffix(key: bytes | str | memoryview, ion: int, *, sep: bytes | str = b"."):
+        """
+        Return iokey after concatenating the hex ordinal suffix to `key` using
+        `sep`.
+
+        Parameters:
+            key (bytes|str|memoryview): apparent effective database key (unsuffixed)
+            ion (int)): insertion ordered ordinal numberfor set of vals
+            sep (bytes): separator character(s) for concatenating suffix
+        """
+        if isinstance(key, memoryview):
+            key = bytes(key)
+        elif hasattr(key, "encode"):
+            key = key.encode()
+        if hasattr(sep, "encode"):
+            sep = sep.encode()
+        ion = b"%032x" % ion
+        return sep.join((key, ion))
+
+    @staticmethod
+    def unsuffix(iokey: bytes | str | memoryview, *, sep: bytes | str = b"."):
+        """
+        Return `(key, ion)` from splitting `iokey` at the rightmost `sep`.
+
+        Parameters:
+            iokey (bytes|str|memoryview): actual database key suffixed
+            sep (bytes): separator character(s) for splitting suffix
+        """
+        if isinstance(iokey, memoryview):
+            iokey = bytes(iokey)
+        elif hasattr(iokey, "encode"):
+            iokey = iokey.encode()
+        if hasattr(sep, "encode"):
+            sep = sep.encode()
+        key, ion = iokey.rsplit(sep=sep, maxsplit=1)
+        ion = int(ion, 16)
+        return (key, ion)
+
+    def _io_items(self, store, key, *, ion=0, sep=b"."):
+        key = _to_bytes(key)
+        iokey = self.suffix(key, ion, sep=sep)
+        for iokey in store.irange(minimum=iokey):
+            ckey, cion = self.unsuffix(iokey, sep=sep)
+            if ckey != key:
+                break
+            yield iokey, bytes(store[iokey])
+
+    def _next_ion(self, store, key, *, sep=b"."):
+        ion = 0
+        for iokey, val in self._io_items(store, key, sep=sep):
+            ckey, cion = self.unsuffix(iokey, sep=sep)
+            ion = cion + 1
+        return ion
+
+    def getIoValFirst(self, sdb, key, *, ion=0, sep=b"."):
+        """Gets first of the insertion ordered set of values at key,
+        None if no entry.
+        Returns the first value at the apparent effective key whose iokey is
+        greater than or equal to the iokey from `ion`, or None if no entry.
+
+        Parameters:
+            sdb (WebSubDb): instance of named sub db with dupsort==False
+            key (bytes): Apparent effective key
+            ion (int): starting ordinal value, default 0
+
+        """
+        for iokey, val in self._io_items(sdb.items, key, ion=ion, sep=sep):
+            return val
+        return None
+
+    def getIoValLast(self, sdb, key, *, sep=b"."):
+        """Gets last value (last in) of insertion ordered set values at key
+        Returns the last value at the apparent effective key, or None if no entry.
+
+        Uses hidden ordinal key suffix for insertion ordering. The suffix is
+        appended and stripped transparently.
+
+        Parameters:
+            sdb (WebSubDb): instance of named sub db with dupsort==False
+            key (bytes): Apparent effective key
+        """
+        val = None
+        for iokey, cval in self._io_items(sdb.items, key, sep=sep):
+            val = cval
+        return val
+
+    def getIoVals(self, sdb, key, *, ion=0, sep=b"."):
+        """Gets list of all the insertion ordered set of values at key
+
+        Returns:
+            vals (list[bytes]): insertion-ordered values at same apparent effective key;
+                hidden ordinal key suffix is used for insertion ordering and stripped transparently.
+
+        Parameters:
+            sdb (WebSubDb): instance of named sub db with dupsort==False
+            key (bytes): Apparent effective key
+            ion (int): starting ordinal value, default 0
+
+        """
+        return [val for iokey, val in self._io_items(sdb.items, key, ion=ion, sep=sep)]
+
+    def getIoValsIter(self, sdb, key, *, ion=0, sep=b"."):
+        """Gets Iterator of all the insertion ordered set of values at key
+
+        Returns:
+            ioset (Iterator): iterator over insertion ordered set of values
+                              at same apparent effective key.
+                              Uses hidden ordinal key suffix for insertion ordering.
+                              The suffix is appended and stripped transparently.
+
+        Raises StopIteration Error when empty.
+
+        Parameters:
+            sdb (WebSubDb): instance of named sub db with dupsort==False
+            key (bytes): Apparent effective key
+            ion (int): starting ordinal value, default 0
+        """
+        for iokey, val in self._io_items(sdb.items, key, ion=ion, sep=sep):
+            yield val
+
+    def popIoVal(self, sdb, key, *, ion=0, sep=b"."):
+        """Pops first of the insertion ordered set of values at key.
+        None if no entry. Pop deletes the returned entry.
+
+        Returns:
+            val (bytes|None): first val at same apparent effective key
+                        whose iokey >= iokey from ion
+                        Uses hidden ordinal key suffix for insertion ordering.
+                        The suffix is appended and stripped transparently.
+                        None if no entry.
+
+        Parameters:
+            sdb (WebSubDb): instance of named sub db with dupsort==False
+            key (bytes): Apparent effective key
+            ion (int): starting ordinal value, default 0
+
+        """
+        for iokey, val in self._io_items(sdb.items, key, ion=ion, sep=sep):
+            del sdb.items[iokey]
+            self._dirty.add(sdb.key)
+            return val
+        return None
+
+    def remIoVals(self, sdb, key, *, sep=b"."):
+        """Deletes all values at apparent effective key.
+        Uses hidden ordinal key suffix for insertion ordering.
+        The suffix is appended and stripped transparently.
+
+        Returns:
+            result (bool): True if at least one value was deleted at key.
+                           False otherwise, if no values at key
+
+        Parameters:
+            sdb (WebSubDb): instance of named sub db with dupsort==False
+            key (bytes): Apparent effective key
+        """
+        keys = [iokey for iokey, val in self._io_items(sdb.items, key, sep=sep)]
+        for iokey in keys:
+            del sdb.items[iokey]
+        if keys:
+            self._dirty.add(sdb.key)
+        return True if keys else False
+
+    def cntIoVals(self, sdb, key, *, sep=b"."):
+        """Count all values with the same apparent effective key.
+        Uses hidden ordinal key suffix for insertion ordering.
+        The suffix is appended and stripped transparently.
+
+        Returns:
+            count (int): count values in set at apparent effective key
+
+        Parameters:
+            sdb (WebSubDb): instance of named sub db with dupsort==False
+            key (bytes): Apparent effective key
+        """
+        return len(self.getIoVals(sdb=sdb, key=key, sep=sep))
+
+    def getTopIoItemIter(self, sdb, top=b"", *, sep=b"."):
+        """Gets Iterator of all values in branch rooted at top key
+        The suffix is appended and stripped transparently.
+
+        Returns:
+            items (Iterator[(key,val)]): iterator of tuples (key, val) where
+                key is apparent key with hidden insertion ordering suffixe removed
+                from effective key. Iterates over top branch of insertion
+                ordered set values where each effective key has trailing hidden
+                suffix of serialization of insertion ordering ordinal.
+
+            Uses hidden ordinal key suffix for insertion ordering.
+
+        Raises StopIteration Error when empty.
+
+        Parameters:
+            sdb (WebSubDb): instance of named sub db with dupsort==False
+            top (bytes): top key in db. When top is empty then every item in db.
+            sep (bytes): sep character for attached io suffix
+        """
+        for iokey, val in self.getTopItemIter(sdb=sdb, top=top):
+            key, ion = self.unsuffix(iokey, sep=sep)
+            yield (key, val)
+
+    def addIoVal(self, sdb, key, val, *, sep=b"."):
+        """Add val at end (append) of insertion ordered set of values all with the
+        same apparent effective key. Does not dedup val.
+        Uses hidden ordinal key suffix for insertion ordering.
+        The suffix is appended and stripped transparently.
+
+        Returns:
+           result (bool): True is added to set. False if already in set.
+
+        Parameters:
+            sdb (WebSubDb): instance of named sub db with dupsort==False
+            key (bytes): Apparent effective key
+            val (bytes): serialized value to add
+
+        """
+        ion = self._next_ion(sdb.items, key, sep=sep)
+        sdb.items[self.suffix(key, ion, sep=sep)] = _to_bytes(val)
+        self._dirty.add(sdb.key)
+        return True
+
+    def putIoVals(self, sdb, key, vals, *, sep=b"."):
+        """Adds at end (append) each val in vals to insertion ordered list of
+        values all with the same apparent effective key for each val.
+        Does not dedup added vals.
+        Uses hidden ordinal key suffix for insertion ordering.
+        The suffix is appended and stripped transparently.
+
+        Returns:
+           result (bool): True if added to set. False if already in set.
+
+        Parameters:
+            sdb (WebSubDb): instance of named sub db with dupsort==False
+            key (bytes): Apparent effective key
+            vals (Iterable): serialized values to add to set of vals at key
+
+        """
+        ion = self._next_ion(sdb.items, key, sep=sep)
+        result = False
+        for offset, val in enumerate(vals):
+            sdb.items[self.suffix(key, ion + offset, sep=sep)] = _to_bytes(val)
+            result = True
+        if result:
+            self._dirty.add(sdb.key)
+        return result
+
+    def pinIoVals(self, sdb, key, vals, *, sep=b"."):
+        """Erase all vals at key and then add vals as insertion ordered set of
+        values all with the same apparent effective key. Does not dedup vals.
+        Uses hidden ordinal key suffix for insertion ordering.
+        The suffix is appended and stripped transparently.
+
+        Returns:
+           result (bool): True is added to set.
+
+        Parameters:
+            sdb (WebSubDb): instance of named sub db with dupsort==False
+            key (bytes): Apparent effective key
+            vals (abc.Iterable): serialized values to add to set of vals at key
+        """
+        old = [iokey for iokey, val in self._io_items(sdb.items, key, sep=sep)]
+        for iokey in old:
+            del sdb.items[iokey]
+        result = False
+        for ion, val in enumerate(vals):
+            sdb.items[self.suffix(key, ion, sep=sep)] = _to_bytes(val)
+            result = True
+        if old or result:
+            self._dirty.add(sdb.key)
+        return result
+
+    def addIoSetVal(self, sdb, key, val, *, sep=b"."):
+        """Add val idempotently to insertion ordered set of values all with the
+        same apparent effective key if val not already in set of vals at key.
+        Dedups the added val.
+        Uses hidden ordinal key suffix for insertion ordering.
+        The suffix is appended and stripped transparently.
+
+        Returns:
+           result (bool): True is added to set. False if already in set.
+
+        Parameters:
+            sdb (WebSubDb): instance of named sub db with dupsort==False
+            key (bytes): Apparent effective key
+            val (bytes): serialized value to add
+
+        """
+        val = _to_bytes(val)
+        vals = oset()
+        ion = 0
+        for iokey, cval in self._io_items(sdb.items, key, sep=sep):
+            vals.add(cval)
+            ckey, cion = self.unsuffix(iokey, sep=sep)
+            ion = cion + 1
+        if val in vals:
+            return False
+        sdb.items[self.suffix(key, ion, sep=sep)] = val
+        self._dirty.add(sdb.key)
+        return True
+
+    def putIoSetVals(self, sdb, key, vals, *, sep=b"."):
+        """Adds idempotently each val in vals to insertion ordered set of values
+        all with the same apparent effective key for each val that is not already
+        in set of vals at key. Dedups the put vals.
+        Uses hidden ordinal key suffix for insertion ordering.
+        The suffix is appended and stripped transparently.
+
+        Returns:
+           result (bool): True if added to set. False if already in set.
+
+        Parameters:
+            sdb (WebSubDb): instance of named sub db with dupsort==False
+            key (bytes): Apparent effective key
+            vals (Iterable): serialized values to add to set of vals at key
+
+        """
+        vals = oset(_to_bytes(val) for val in vals)
+        pvals = oset()
+        ion = 0
+        for iokey, cval in self._io_items(sdb.items, key, sep=sep):
+            pvals.add(cval)
+            ckey, cion = self.unsuffix(iokey, sep=sep)
+            ion = cion + 1
+        vals -= pvals
+        result = False
+        for offset, val in enumerate(vals):
+            sdb.items[self.suffix(key, ion + offset, sep=sep)] = val
+            result = True
+        if result:
+            self._dirty.add(sdb.key)
+        return result
+
+    def pinIoSetVals(self, sdb, key, vals, *, sep=b"."):
+        """Erase all vals at key and then add unique vals as insertion ordered set of
+        values all with the same apparent effective key. Dedups the set vals.
+        Uses hidden ordinal key suffix for insertion ordering.
+        The suffix is appended and stripped transparently.
+
+        Returns:
+           result (bool): True is added to set.
+
+        Parameters:
+            sdb (WebSubDb): instance of named sub db with dupsort==False
+            key (bytes): Apparent effective key
+            vals (abc.Iterable): serialized values to add to set of vals at key
+        """
+        old = [iokey for iokey, val in self._io_items(sdb.items, key, sep=sep)]
+        for iokey in old:
+            del sdb.items[iokey]
+        result = False
+        vals = oset(_to_bytes(val) for val in vals)
+        for ion, val in enumerate(vals):
+            sdb.items[self.suffix(key, ion, sep=sep)] = val
+            result = True
+        if old or result:
+            self._dirty.add(sdb.key)
+        return result
+
+    def remIoSetVal(self, sdb, key, val, *, sep=b"."):
+        """Removes (delete) matching val at apparent effective key if exists.
+        Uses hidden ordinal key suffix for insertion ordering.
+        The suffix is appended and stripped transparently.
+
+        Because the insertion order of val is not provided must perform a linear
+        search over set of values.
+
+        Another problem is that vals may get added and deleted in any order so
+        the max suffix ion may creep up over time. The suffix ordinal max > 2**16
+        is an impossibly large number, however, so the suffix will not max out
+        practically.But its not the most elegant solution.
+
+        In some cases a better approach would be to use getIoSetItemsIter which
+        returns the actual iokey not the apparent effetive key so can delete
+        using the iokey without searching for the value. This is most applicable
+        when processing escrows where all the escrowed items are processed linearly
+        and one needs to delete some of them in stride with their processing.
+
+        Returns:
+            result (bool): True if val was deleted at key. False otherwise
+                if val not found at key
+
+        Parameters:
+            sdb (WebSubDb): instance of named sub db with dupsort==False
+            key (bytes): Apparent effective key
+            val (bytes): value to delete
+        """
+        val = _to_bytes(val)
+        for iokey, cval in self._io_items(sdb.items, key, sep=sep):
+            if val == cval:
+                del sdb.items[iokey]
+                self._dirty.add(sdb.key)
+                return True
+        return False
+
+
+@asynccontextmanager
+async def openWebDuror(*, cls=None, name="test", temp=True, clear=False, **kwa):
+    """Async context manager wrapper for WebDuror instances."""
+    duror = None
+    if cls is None:
+        cls = WebDuror
+    try:
+        duror = cls(name=name, temp=temp, reopen=False, clear=clear, **kwa)
+        await duror.reopen(clear=clear)
+        yield duror
+    finally:
+        if duror:
+            await duror.aclose(clear=clear or duror.temp)

--- a/src/hio/base/webduring.py
+++ b/src/hio/base/webduring.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from contextlib import asynccontextmanager
 import json
 
@@ -21,6 +22,28 @@ except ImportError:  # pragma: no cover
 
 
 _RECORDS_KEY = "__records__"
+
+
+async def _clear_handles(handles):
+    """Clear persisted records for captured browser storage handles."""
+    for handle in handles.values():
+        handle[_RECORDS_KEY] = "{}"
+        await handle.sync()
+
+
+async def _persist_stores(handles, stores, dirty):
+    """Persist captured dirty stores through captured browser storage handles."""
+    persisted = []
+    for store in tuple(stores):
+        if store not in dirty:
+            continue
+        handles[store][_RECORDS_KEY] = json.dumps(
+            {key.hex(): val.hex() for key, val in stores[store].items()},
+            sort_keys=True,
+        )
+        await handles[store].sync()
+        persisted.append(store)
+    return persisted
 
 
 def _to_bytes(value):
@@ -175,11 +198,23 @@ class WebDuror(Filer):
         return self.opened
 
     def close(self, clear=False):
-        """Close local handles and clear in-memory store state.
+        """Close local handles after persisting or clearing pending state.
 
-        Use await flush() or await aclose() to persist pending writes.
-        Use await aclose(clear=True) to clear persisted browser storage.
+        When called inside a running loop, persistence is scheduled on that loop.
+        Use await aclose() when the caller must wait for completion.
         """
+        if self.opened and (clear or self._dirty):
+            handles = dict(self._handles)
+            stores = {store: SortedDict(items) for store, items in self._stores.items()}
+            dirty = set(self._dirty)
+            task = _clear_handles(handles) if clear else _persist_stores(handles, stores, dirty)
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                asyncio.run(task)
+            else:
+                loop.create_task(task)
+
         self.env = None
         self.opened = False
         self._stores = {}
@@ -190,12 +225,12 @@ class WebDuror(Filer):
 
     async def aclose(self, clear=False):
         """Flush pending writes, optionally clear persisted browser records, and close."""
-        if self.opened and self._dirty and not clear:
-            await self.flush()
-        if self.opened and clear:
-            for handle in self._handles.values():
-                handle[_RECORDS_KEY] = "{}"
-                await handle.sync()
+        if self.opened:
+            if clear:
+                await _clear_handles(dict(self._handles))
+                self._dirty.clear()
+            elif self._dirty:
+                await self.flush()
         self.close()
         return self.opened
 
@@ -205,18 +240,9 @@ class WebDuror(Filer):
             return 0
         if not self.opened:
             raise HierError("WebDuror is not open.")
-        count = 0
-        for store in tuple(self._stores):
-            if store not in self._dirty:
-                continue
-            self._handles[store][_RECORDS_KEY] = json.dumps(
-                {key.hex(): val.hex() for key, val in self._stores[store].items()},
-                sort_keys=True,
-            )
-            await self._handles[store].sync()
-            self._dirty.remove(store)
-            count += 1
-        return count
+        persisted = await _persist_stores(self._handles, self._stores, self._dirty)
+        self._dirty.difference_update(persisted)
+        return len(persisted)
 
     @property
     def version(self):

--- a/tests/base/test_webduring.py
+++ b/tests/base/test_webduring.py
@@ -337,3 +337,56 @@ def test_webduror_flush_aclose_reopen_and_clear():
         await cleared.aclose()
 
     run(main())
+
+
+def test_webduror_sync_close_flushes_and_clears_on_running_loop():
+    async def main():
+        storage = FakeStorageBackend()
+        writer = WebDuror(storageOpener=storage.open)
+        await writer.reopen(stores=(b"docs.",))
+        sdb = writer.env.open_db(key=b"docs.")
+        assert writer.pinVal(sdb=sdb, key=b"key", val=b"value")
+
+        assert writer.close()
+        await asyncio.sleep(0)
+
+        reader = WebDuror(storageOpener=storage.open)
+        await reader.reopen(stores=(b"docs.",))
+        rsdb = reader.env.open_db(key=b"docs.")
+        assert reader.getVal(sdb=rsdb, key=b"key") == b"value"
+        assert reader.pinVal(sdb=rsdb, key=b"next", val=b"value")
+
+        assert reader.close(clear=True)
+        await asyncio.sleep(0)
+
+        cleared = WebDuror(storageOpener=storage.open)
+        await cleared.reopen(stores=(b"docs.",))
+        csdb = cleared.env.open_db(key=b"docs.")
+        assert cleared.getVal(sdb=csdb, key=b"key") is None
+        assert cleared.getVal(sdb=csdb, key=b"next") is None
+        await cleared.aclose()
+
+    run(main())
+
+
+def test_webduror_sync_close_flushes_without_running_loop():
+    storage = FakeStorageBackend()
+    writer = WebDuror(storageOpener=storage.open)
+    run(writer.reopen(stores=(b"docs.",)))
+    sdb = writer.env.open_db(key=b"docs.")
+    assert writer.pinVal(sdb=sdb, key=b"key", val=b"value")
+
+    assert writer.close()
+
+    reader = WebDuror(storageOpener=storage.open)
+    run(reader.reopen(stores=(b"docs.",)))
+    rsdb = reader.env.open_db(key=b"docs.")
+    assert reader.getVal(sdb=rsdb, key=b"key") == b"value"
+
+    assert reader.close(clear=True)
+
+    cleared = WebDuror(storageOpener=storage.open)
+    run(cleared.reopen(stores=(b"docs.",)))
+    csdb = cleared.env.open_db(key=b"docs.")
+    assert cleared.getVal(sdb=csdb, key=b"key") is None
+    run(cleared.aclose())

--- a/tests/base/test_webduring.py
+++ b/tests/base/test_webduring.py
@@ -2,11 +2,6 @@
 """Browser-safe WebDuror contract tests."""
 
 import asyncio
-import os
-from pathlib import Path
-import subprocess
-import sys
-import textwrap
 
 import pytest
 
@@ -22,59 +17,6 @@ from hio.base import (
     openWebDuror,
 )
 from hio.base.hier import Can
-
-
-def test_webduror_import_path_does_not_load_native_deps():
-    """Import browser-reachable modules without pulling native-only deps."""
-    root = Path(__file__).resolve().parents[2]
-    script = textwrap.dedent(
-        """
-        import importlib.abc
-        import sys
-
-
-        class BlockNativeDeps(importlib.abc.MetaPathFinder):
-            def find_spec(self, fullname, path=None, target=None):
-                blocked = ("lmdb", "pysodium", "pychloride")
-                if fullname in blocked or fullname.startswith(tuple(f"{name}." for name in blocked)):
-                    raise ImportError(f"blocked {fullname} for browser import test")
-                return None
-
-
-        sys.meta_path.insert(0, BlockNativeDeps())
-        for name in ("lmdb", "pysodium", "pychloride"):
-            sys.modules.pop(name, None)
-
-        import hio.base
-        import hio.base.hier
-        from hio.base import WebDuror, openWebDuror, webduring
-        from hio.base.hier import Can, Durq, Dusq, Hold
-
-        assert "hio.base.during" not in sys.modules
-        assert "lmdb" not in sys.modules
-        assert "pysodium" not in sys.modules
-        assert "pychloride" not in sys.modules
-        assert webduring.WebDuror is WebDuror
-        assert openWebDuror.__name__ == "openWebDuror"
-        assert Can.__name__ == "Can"
-        assert Durq.__name__ == "Durq"
-        assert Dusq.__name__ == "Dusq"
-        assert Hold.__name__ == "Hold"
-        """
-    )
-    env = os.environ.copy()
-    env["PYTHONPATH"] = os.pathsep.join(
-        part for part in (str(root / "src"), env.get("PYTHONPATH", "")) if part
-    )
-    result = subprocess.run(
-        [sys.executable, "-c", script],
-        cwd=root,
-        env=env,
-        capture_output=True,
-        text=True,
-        timeout=10,
-    )
-    assert result.returncode == 0, result.stderr + result.stdout
 
 
 def run(coro):
@@ -128,13 +70,10 @@ def test_webduror_constructor_lifecycle():
         storage = FakeStorageBackend()
         duror = WebDuror(storageOpener=storage.open)
         assert not duror.opened
-        assert duror.path is None
 
         assert await duror.reopen(stores=(b"docs.",))
         docs = duror.env.open_db(key=b"docs.")
         assert docs.flags() == {"dupsort": False}
-        assert duror.env.open_db(key=None).key == WebDuror.MetaStore
-        assert storage.opened == ["main:__meta__", "main:docs."]
 
         with pytest.raises(hio.HierError, match="not declared"):
             duror.env.open_db(key=b"unknown.")
@@ -396,15 +335,5 @@ def test_webduror_flush_aclose_reopen_and_clear():
         csdb = cleared.env.open_db(key=b"docs.")
         assert cleared.getVal(sdb=csdb, key=b"key") is None
         await cleared.aclose()
-
-    run(main())
-
-
-def test_open_webduror_async_context_manager():
-    async def main():
-        storage = FakeStorageBackend()
-        async with openWebDuror(stores=(b"docs.",), storageOpener=storage.open) as duror:
-            sdb = duror.env.open_db(key=b"docs.")
-            assert duror.putVal(sdb=sdb, key=b"a", val=b"b")
 
     run(main())

--- a/tests/base/test_webduring.py
+++ b/tests/base/test_webduring.py
@@ -1,0 +1,410 @@
+# -*- encoding: utf-8 -*-
+"""Browser-safe WebDuror contract tests."""
+
+import asyncio
+import os
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+import hio
+from hio.base import (
+    DomIoSetSuber,
+    DomIoSuber,
+    DomSuber,
+    IoSetSuber,
+    IoSuber,
+    Suber,
+    WebDuror,
+    openWebDuror,
+)
+from hio.base.hier import Can
+
+
+def test_webduror_import_path_does_not_load_native_deps():
+    """Import browser-reachable modules without pulling native-only deps."""
+    root = Path(__file__).resolve().parents[2]
+    script = textwrap.dedent(
+        """
+        import importlib.abc
+        import sys
+
+
+        class BlockNativeDeps(importlib.abc.MetaPathFinder):
+            def find_spec(self, fullname, path=None, target=None):
+                blocked = ("lmdb", "pysodium", "pychloride")
+                if fullname in blocked or fullname.startswith(tuple(f"{name}." for name in blocked)):
+                    raise ImportError(f"blocked {fullname} for browser import test")
+                return None
+
+
+        sys.meta_path.insert(0, BlockNativeDeps())
+        for name in ("lmdb", "pysodium", "pychloride"):
+            sys.modules.pop(name, None)
+
+        import hio.base
+        import hio.base.hier
+        from hio.base import WebDuror, openWebDuror, webduring
+        from hio.base.hier import Can, Durq, Dusq, Hold
+
+        assert "hio.base.during" not in sys.modules
+        assert "lmdb" not in sys.modules
+        assert "pysodium" not in sys.modules
+        assert "pychloride" not in sys.modules
+        assert webduring.WebDuror is WebDuror
+        assert openWebDuror.__name__ == "openWebDuror"
+        assert Can.__name__ == "Can"
+        assert Durq.__name__ == "Durq"
+        assert Dusq.__name__ == "Dusq"
+        assert Hold.__name__ == "Hold"
+        """
+    )
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        part for part in (str(root / "src"), env.get("PYTHONPATH", "")) if part
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=root,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+class FakeStorageHandle:
+    """Async storage handle with local writes and explicit sync commit."""
+
+    def __init__(self, backend, namespace):
+        self.backend = backend
+        self.namespace = namespace
+        self._local = dict(self.backend.persisted.get(namespace, {}))
+
+    def get(self, key, default=None):
+        return self._local.get(key, default)
+
+    def __getitem__(self, key):
+        return self._local[key]
+
+    def __setitem__(self, key, value):
+        self._local[key] = value
+
+    async def sync(self):
+        self.backend.synced.append(self.namespace)
+        self.backend.persisted[self.namespace] = dict(self._local)
+
+
+class FakeStorageBackend:
+    """Minimal async opener that mimics PyScript storage commit semantics."""
+
+    def __init__(self):
+        self.persisted = {}
+        self.opened = []
+        self.synced = []
+
+    async def open(self, namespace):
+        self.opened.append(namespace)
+        return FakeStorageHandle(self, namespace)
+
+
+def test_webduror_constructor_lifecycle():
+    async def main():
+        with pytest.raises(hio.HierError, match="async open"):
+            WebDuror(reopen=True)
+
+        duror = WebDuror()
+        with pytest.raises(hio.HierError, match="requires pyscript.storage or storageOpener"):
+            await duror.reopen(stores=(b"docs.",))
+
+        storage = FakeStorageBackend()
+        duror = WebDuror(storageOpener=storage.open)
+        assert not duror.opened
+        assert duror.path is None
+
+        assert await duror.reopen(stores=(b"docs.",))
+        docs = duror.env.open_db(key=b"docs.")
+        assert docs.flags() == {"dupsort": False}
+        assert duror.env.open_db(key=None).key == WebDuror.MetaStore
+        assert storage.opened == ["main:__meta__", "main:docs."]
+
+        with pytest.raises(hio.HierError, match="not declared"):
+            duror.env.open_db(key=b"unknown.")
+
+        await duror.aclose()
+
+    run(main())
+
+
+def test_webduror_base_namespaces_are_isolated():
+    async def main():
+        storage = FakeStorageBackend()
+        first = WebDuror(name="same", base="a", storageOpener=storage.open)
+        await first.reopen(stores=(b"docs.",))
+        fsdb = first.env.open_db(key=b"docs.")
+        assert first.pinVal(sdb=fsdb, key=b"k", val=b"a")
+        await first.aclose()
+
+        same = WebDuror(name="same", base="a", storageOpener=storage.open)
+        await same.reopen(stores=(b"docs.",))
+        ssdb = same.env.open_db(key=b"docs.")
+        assert same.getVal(sdb=ssdb, key=b"k") == b"a"
+        await same.aclose()
+
+        other = WebDuror(name="same", base="b", storageOpener=storage.open)
+        await other.reopen(stores=(b"docs.",))
+        osdb = other.env.open_db(key=b"docs.")
+        assert other.getVal(sdb=osdb, key=b"k") is None
+        await other.aclose(clear=True)
+
+        cleanup = WebDuror(name="same", base="a", storageOpener=storage.open)
+        await cleanup.reopen(stores=(b"docs.",))
+        await cleanup.aclose(clear=True)
+
+    run(main())
+
+
+def test_webduror_aclose_and_context_cleanup_edges():
+    async def main():
+        unopened = WebDuror()
+        assert await unopened.aclose(clear=True) is False
+
+        async def broken_opener(namespace):
+            raise RuntimeError(f"open failed for {namespace}")
+
+        with pytest.raises(RuntimeError, match="open failed"):
+            async with openWebDuror(stores=(b"docs.",), storageOpener=broken_opener):
+                raise AssertionError("unreachable")
+
+    run(main())
+
+
+def test_webduror_version_persists_through_flush_and_reopen():
+    async def main():
+        storage = FakeStorageBackend()
+        duror = WebDuror(storageOpener=storage.open)
+        await duror.reopen(stores=(b"docs.",))
+        assert duror.version == hio.__version__
+
+        duror.version = "1.2.3"
+        assert await duror.flush() == 1
+        await duror.aclose()
+
+        reopened = WebDuror(storageOpener=storage.open)
+        await reopened.reopen(stores=(b"docs.",))
+        assert reopened.getVer() == "1.2.3"
+        reopened.version = "2.0.0"
+        await reopened.flush()
+        await reopened.aclose()
+
+        final = WebDuror(storageOpener=storage.open)
+        await final.reopen(stores=(b"docs.",))
+        assert final.version == "2.0.0"
+        await final.aclose()
+
+    run(main())
+
+
+def test_webduror_plain_values_and_suffix_parity():
+    async def main():
+        storage = FakeStorageBackend()
+        duror = WebDuror(storageOpener=storage.open)
+        await duror.reopen(stores=(b"beep.",))
+        sdb = duror.env.open_db(key=b"beep.")
+
+        assert duror.getVal(sdb=sdb, key=b"A") is None
+        assert not duror.remVal(sdb=sdb, key=b"A")
+        assert duror.putVal(sdb=sdb, key=b"A", val=b"whatever")
+        assert not duror.putVal(sdb=sdb, key=b"A", val=b"ignored")
+        assert duror.getVal(sdb=sdb, key=b"A") == b"whatever"
+        assert duror.pinVal(sdb=sdb, key=b"A", val=b"\xff\x00")
+        assert duror.getVal(sdb=sdb, key=b"A") == b"\xff\x00"
+        assert duror.pinVal(sdb=sdb, key=b"\xff\x00.key", val=b"\x00\xff.value")
+        assert await duror.flush() == 1
+        await duror.reopen(stores=(b"beep.",))
+        sdb = duror.env.open_db(key=b"beep.")
+        assert duror.getVal(sdb=sdb, key=b"\xff\x00.key") == b"\x00\xff.value"
+        assert duror.cntVals(sdb=sdb) == 2
+        assert duror.remVal(sdb=sdb, key=b"A")
+        assert duror.remVal(sdb=sdb, key=b"\xff\x00.key")
+        assert duror.getVal(sdb=sdb, key=b"A") is None
+
+        for key, val in ((b"a.1", b"wow"), (b"a.2", b"wee"), (b"b.1", b"woo")):
+            assert duror.putVal(sdb=sdb, key=key, val=val)
+        assert list(duror.getTopItemIter(sdb=sdb)) == [
+            (b"a.1", b"wow"),
+            (b"a.2", b"wee"),
+            (b"b.1", b"woo"),
+        ]
+        assert duror.remTopVals(sdb=sdb, top=b"a.")
+        assert list(duror.getTopItemIter(sdb=sdb)) == [(b"b.1", b"woo")]
+        assert duror.remTopVals(sdb=sdb)
+        assert duror.cntVals(sdb=sdb) == 0
+
+        key = "ABCDEFG.FFFFFF"
+        assert WebDuror.suffix(key, 0) == b"ABCDEFG.FFFFFF.00000000000000000000000000000000"
+        assert WebDuror.suffix(key.encode(), 64) == b"ABCDEFG.FFFFFF.00000000000000000000000000000040"
+        maxed = WebDuror.suffix(key, WebDuror.MaxSuffix)
+        assert maxed == b"ABCDEFG.FFFFFF.ffffffffffffffffffffffffffffffff"
+        assert WebDuror.unsuffix(maxed) == (b"ABCDEFG.FFFFFF", WebDuror.MaxSuffix)
+
+        await duror.aclose(clear=True)
+
+    run(main())
+
+
+def test_webduror_io_and_ioset_parity():
+    async def main():
+        storage = FakeStorageBackend()
+        duror = WebDuror(storageOpener=storage.open)
+        await duror.reopen(stores=(b"io.", b"ioset."))
+
+        key0 = b"ABC_ZYX"
+        key1 = b"DEF_WVU"
+        key2 = b"GHI_TSR"
+        vals0 = [b"z", b"m", b"x", b"a"]
+        vals1 = [b"w", b"n", b"y", b"d"]
+        vals2 = [b"p", b"o", b"h", b"f"]
+
+        sdb = duror.env.open_db(key=b"io.")
+        assert duror.getIoVals(sdb=sdb, key=key0) == []
+        assert duror.getIoValFirst(sdb=sdb, key=key0) is None
+        assert duror.getIoValLast(sdb=sdb, key=key0) is None
+        assert not duror.remIoVals(sdb=sdb, key=key0)
+
+        assert duror.putIoVals(sdb=sdb, key=key0, vals=vals0)
+        assert duror.getIoVals(sdb=sdb, key=key0) == vals0
+        assert duror.addIoVal(sdb=sdb, key=key0, val=b"a")
+        assert duror.getIoVals(sdb=sdb, key=key0) == vals0 + [b"a"]
+        assert duror.getIoValFirst(sdb=sdb, key=key0) == b"z"
+        assert duror.getIoValLast(sdb=sdb, key=key0) == b"a"
+        assert duror.popIoVal(sdb=sdb, key=key0) == b"z"
+        assert duror.pinIoVals(sdb=sdb, key=key0, vals=[b"q", b"e"])
+        assert duror.getIoVals(sdb=sdb, key=key0) == [b"q", b"e"]
+
+        assert duror.putIoVals(sdb=sdb, key=key1, vals=vals1)
+        assert duror.putIoVals(sdb=sdb, key=key2, vals=vals2)
+        assert list(duror.getTopIoItemIter(sdb=sdb, top=b"DEF")) == [
+            (b"DEF_WVU", b"w"),
+            (b"DEF_WVU", b"n"),
+            (b"DEF_WVU", b"y"),
+            (b"DEF_WVU", b"d"),
+        ]
+
+        sdb = duror.env.open_db(key=b"ioset.")
+        assert duror.putIoSetVals(sdb=sdb, key=key0, vals=vals0)
+        assert not duror.putIoSetVals(sdb=sdb, key=key0, vals=[b"a"])
+        assert duror.addIoSetVal(sdb=sdb, key=key0, val=b"b")
+        assert not duror.addIoSetVal(sdb=sdb, key=key0, val=b"a")
+        assert duror.getIoVals(sdb=sdb, key=key0) == vals0 + [b"b"]
+        assert duror.remIoSetVal(sdb=sdb, key=key0, val=b"x")
+        assert duror.getIoVals(sdb=sdb, key=key0) == [b"z", b"m", b"a", b"b"]
+        assert duror.pinIoSetVals(sdb=sdb, key=key0, vals=[b"z", b"z", b"a"])
+        assert duror.getIoVals(sdb=sdb, key=key0) == [b"z", b"a"]
+        assert duror.popIoVal(sdb=sdb, key=key0) == b"z"
+        assert duror.cntIoVals(sdb=sdb, key=key0) == 1
+
+        await duror.aclose(clear=True)
+
+    run(main())
+
+
+def test_existing_wrappers_work_against_webduror():
+    async def main():
+        storage = FakeStorageBackend()
+        duror = WebDuror(storageOpener=storage.open)
+        await duror.reopen(stores=(b"bags.", b"io.", b"ioset.", b"cans.", b"drqs.", b"dsqs."))
+
+        suber = Suber(db=duror, subkey="bags.")
+        assert not suber.sdb.flags()["dupsort"]
+        assert suber.put(keys=("a", "1"), val="alpha")
+        assert not suber.put(keys=("a", "1"), val="ignored")
+        assert suber.pin(keys=("a", "1"), val="beta")
+        assert suber.get(keys=("a", "1")) == "beta"
+        assert suber.rem(keys=("a", "1"))
+
+        io = IoSuber(db=duror, subkey="io.")
+        assert io.put(keys=("queue", "1"), vals=["one", "two"])
+        assert io.get(keys=("queue", "1")) == ["one", "two"]
+        assert io.pop(keys=("queue", "1")) == "one"
+        assert io.get(keys=("queue", "1")) == ["two"]
+
+        ioset = IoSetSuber(db=duror, subkey="ioset.")
+        assert ioset.put(keys=("set", "1"), vals=["one", "two"])
+        assert not ioset.add(keys=("set", "1"), val="one")
+        assert ioset.add(keys=("set", "1"), val="three")
+        assert ioset.get(keys=("set", "1")) == ["one", "two", "three"]
+        assert ioset.rem(keys=("set", "1"), val="two")
+        assert ioset.get(keys=("set", "1")) == ["one", "three"]
+
+        dom = DomSuber(db=duror, subkey="cans.")
+        dom.pin(keys="can", val=Can(value="alpha"))
+        assert isinstance(dom.get(keys="can"), Can)
+        assert dom.get(keys="can").value == "alpha"
+
+        domio = DomIoSuber(db=duror, subkey="drqs.")
+        assert domio.put(keys="queue", vals=[Can(value="one"), Can(value="two")])
+        assert [can.value for can in domio.get(keys="queue")] == ["one", "two"]
+
+        domioset = DomIoSetSuber(db=duror, subkey="dsqs.")
+        assert domioset.put(keys="set", vals=[Can(value="one"), Can(value="one"), Can(value="two")])
+        assert [can.value for can in domioset.get(keys="set")] == ["one", "two"]
+
+        await duror.flush()
+        await duror.aclose()
+
+    run(main())
+
+
+def test_webduror_flush_aclose_reopen_and_clear():
+    async def main():
+        storage = FakeStorageBackend()
+        writer = WebDuror(storageOpener=storage.open)
+        await writer.reopen(stores=(b"docs.",))
+        sdb = writer.env.open_db(key=b"docs.")
+        assert writer.pinVal(sdb=sdb, key=b"key", val=b"value")
+
+        reader = WebDuror(storageOpener=storage.open)
+        await reader.reopen(stores=(b"docs.",))
+        rsdb = reader.env.open_db(key=b"docs.")
+        assert reader.getVal(sdb=rsdb, key=b"key") is None
+        await reader.aclose()
+
+        assert await writer.flush() == 1
+        await writer.reopen(stores=(b"docs.",))
+        sdb = writer.env.open_db(key=b"docs.")
+        assert writer.getVal(sdb=sdb, key=b"key") == b"value"
+
+        assert writer.pinVal(sdb=sdb, key=b"next", val=b"value")
+        await writer.aclose()
+        reopened = WebDuror(storageOpener=storage.open)
+        await reopened.reopen(stores=(b"docs.",))
+        rsdb = reopened.env.open_db(key=b"docs.")
+        assert reopened.getVal(sdb=rsdb, key=b"next") == b"value"
+        await reopened.aclose(clear=True)
+
+        cleared = WebDuror(storageOpener=storage.open)
+        await cleared.reopen(stores=(b"docs.",))
+        csdb = cleared.env.open_db(key=b"docs.")
+        assert cleared.getVal(sdb=csdb, key=b"key") is None
+        await cleared.aclose()
+
+    run(main())
+
+
+def test_open_webduror_async_context_manager():
+    async def main():
+        storage = FakeStorageBackend()
+        async with openWebDuror(stores=(b"docs.",), storageOpener=storage.open) as duror:
+            sdb = duror.env.open_db(key=b"docs.")
+            assert duror.putVal(sdb=sdb, key=b"a", val=b"b")
+
+    run(main())

--- a/tests/wasm/__init__.py
+++ b/tests/wasm/__init__.py
@@ -1,0 +1,1 @@
+# -*- encoding: utf-8 -*-

--- a/tests/wasm/test_webduring_wasm.py
+++ b/tests/wasm/test_webduring_wasm.py
@@ -19,7 +19,7 @@ pytest_pyodide = pytest.importorskip("pytest_pyodide")
 run_in_pyodide = pytest_pyodide.run_in_pyodide
 copy_files_to_pyodide = pytest_pyodide.decorator.copy_files_to_pyodide
 
-WASM_PACKAGES = ["cbor2", "micropip", "msgpack", "multidict", "sortedcontainers"]
+WASM_PACKAGES = ["micropip", "msgpack", "multidict", "sortedcontainers"]
 
 HIO_FILES = [
     ("src/hio/__init__.py", "/home/pyodide/hio/__init__.py"),
@@ -50,7 +50,7 @@ async def test_webduror_wasm_contract(selenium):
     import sys
     import micropip
 
-    await micropip.install("ordered_set")
+    await micropip.install(["cbor2==5.9.0", "ordered_set"])
     sys.path.insert(0, "/home/pyodide")
 
     import hio

--- a/tests/wasm/test_webduring_wasm.py
+++ b/tests/wasm/test_webduring_wasm.py
@@ -42,7 +42,7 @@ async def test_webduror_wasm_contract(selenium):
 
     await micropip.install(["cbor2==5.9.0", "ordered_set"])
     hio_wheel = next(Path("/home/pyodide").glob("hio-*.whl"))
-    await micropip.install(str(hio_wheel), deps=False)
+    await micropip.install(f"emfs:{hio_wheel}", deps=False)
 
     import hio
     import hio.base

--- a/tests/wasm/test_webduring_wasm.py
+++ b/tests/wasm/test_webduring_wasm.py
@@ -1,0 +1,125 @@
+# -*- encoding: utf-8 -*-
+"""
+tests.wasm.test_webduring_wasm module
+
+WASM smoke tests for WebDuror, run inside Pyodide via pytest-pyodide.
+"""
+import os
+
+import pytest
+
+
+if os.environ.get("RUN_WASM_TESTS") != "true":
+    pytest.skip(
+        "WASM tests require RUN_WASM_TESTS=true with a pytest-pyodide runtime",
+        allow_module_level=True,
+    )
+
+pytest_pyodide = pytest.importorskip("pytest_pyodide")
+run_in_pyodide = pytest_pyodide.run_in_pyodide
+copy_files_to_pyodide = pytest_pyodide.decorator.copy_files_to_pyodide
+
+WASM_PACKAGES = ["cbor2", "micropip", "msgpack", "multidict", "sortedcontainers"]
+
+HIO_FILES = [
+    ("src/hio/__init__.py", "/home/pyodide/hio/__init__.py"),
+    ("src/hio/hioing.py", "/home/pyodide/hio/hioing.py"),
+    ("src/hio/base/__init__.py", "/home/pyodide/hio/base/__init__.py"),
+    ("src/hio/base/basing.py", "/home/pyodide/hio/base/basing.py"),
+    ("src/hio/base/doing.py", "/home/pyodide/hio/base/doing.py"),
+    ("src/hio/base/during.py", "/home/pyodide/hio/base/during.py"),
+    ("src/hio/base/filing.py", "/home/pyodide/hio/base/filing.py"),
+    ("src/hio/base/tyming.py", "/home/pyodide/hio/base/tyming.py"),
+    ("src/hio/base/webduring.py", "/home/pyodide/hio/base/webduring.py"),
+    ("src/hio/help/__init__.py", "/home/pyodide/hio/help/__init__.py"),
+    ("src/hio/help/decking.py", "/home/pyodide/hio/help/decking.py"),
+    ("src/hio/help/doming.py", "/home/pyodide/hio/help/doming.py"),
+    ("src/hio/help/helping.py", "/home/pyodide/hio/help/helping.py"),
+    ("src/hio/help/hicting.py", "/home/pyodide/hio/help/hicting.py"),
+    ("src/hio/help/mining.py", "/home/pyodide/hio/help/mining.py"),
+    ("src/hio/help/naming.py", "/home/pyodide/hio/help/naming.py"),
+    ("src/hio/help/ogling.py", "/home/pyodide/hio/help/ogling.py"),
+    ("src/hio/help/timing.py", "/home/pyodide/hio/help/timing.py"),
+]
+
+
+@copy_files_to_pyodide(file_list=HIO_FILES)
+@run_in_pyodide(packages=WASM_PACKAGES)
+async def test_webduror_wasm_contract(selenium):
+    """Verify WebDuror imports and core storage behavior in WASM."""
+    import sys
+    import micropip
+
+    await micropip.install("ordered_set")
+    sys.path.insert(0, "/home/pyodide")
+
+    import hio
+    import hio.base
+    from hio.base import WebDuror
+
+    assert "hio.base.during" not in sys.modules
+    assert "pysodium" not in sys.modules
+    assert "pychloride" not in sys.modules
+
+    class FakeHandle:
+        def __init__(self, backend, namespace):
+            self.backend = backend
+            self.namespace = namespace
+            self._local = dict(self.backend.persisted.get(namespace, {}))
+
+        def get(self, key, default=None):
+            return self._local.get(key, default)
+
+        def __getitem__(self, key):
+            return self._local[key]
+
+        def __setitem__(self, key, value):
+            self._local[key] = value
+
+        async def sync(self):
+            self.backend.persisted[self.namespace] = dict(self._local)
+
+    class FakeBackend:
+        def __init__(self):
+            self.persisted = {}
+
+        async def open(self, namespace):
+            return FakeHandle(self, namespace)
+
+    backend = FakeBackend()
+    duror = WebDuror(name="wasm", storageOpener=backend.open)
+    await duror.reopen(stores=(b"docs.", b"io.", b"ioset."))
+    docs = duror.env.open_db(key=b"docs.")
+    io = duror.env.open_db(key=b"io.")
+    ioset = duror.env.open_db(key=b"ioset.")
+
+    assert duror.version == hio.__version__
+    assert duror.pinVal(sdb=docs, key=b"alpha", val=b"one")
+    assert duror.pinVal(sdb=docs, key=b"\xff.key", val=b"\x00.value")
+    assert duror.addIoVal(sdb=io, key=b"queue", val=b"first")
+    assert duror.putIoSetVals(sdb=ioset, key=b"set", vals=[b"a", b"a", b"b"])
+    assert duror.getIoVals(sdb=ioset, key=b"set") == [b"a", b"b"]
+    assert await duror.flush() == 3
+    await duror.aclose()
+
+    reopened = WebDuror(name="wasm", storageOpener=backend.open)
+    await reopened.reopen(stores=(b"docs.", b"io.", b"ioset."))
+    docs = reopened.env.open_db(key=b"docs.")
+    io = reopened.env.open_db(key=b"io.")
+    ioset = reopened.env.open_db(key=b"ioset.")
+
+    assert reopened.getVal(sdb=docs, key=b"alpha") == b"one"
+    assert reopened.getVal(sdb=docs, key=b"\xff.key") == b"\x00.value"
+    assert reopened.getIoVals(sdb=io, key=b"queue") == [b"first"]
+    assert reopened.getIoVals(sdb=ioset, key=b"set") == [b"a", b"b"]
+    await reopened.aclose(clear=True)
+
+    cleared = WebDuror(name="wasm", storageOpener=backend.open)
+    await cleared.reopen(stores=(b"docs.",))
+    docs = cleared.env.open_db(key=b"docs.")
+    assert cleared.getVal(sdb=docs, key=b"alpha") is None
+    await cleared.aclose()
+
+    assert "hio.base.during" not in sys.modules
+    assert "pysodium" not in sys.modules
+    assert "pychloride" not in sys.modules

--- a/tests/wasm/test_webduring_wasm.py
+++ b/tests/wasm/test_webduring_wasm.py
@@ -5,6 +5,7 @@ tests.wasm.test_webduring_wasm module
 WASM smoke tests for WebDuror, run inside Pyodide via pytest-pyodide.
 """
 import os
+from pathlib import Path
 
 import pytest
 
@@ -21,37 +22,27 @@ copy_files_to_pyodide = pytest_pyodide.decorator.copy_files_to_pyodide
 
 WASM_PACKAGES = ["micropip", "msgpack", "multidict", "sortedcontainers"]
 
-HIO_FILES = [
-    ("src/hio/__init__.py", "/home/pyodide/hio/__init__.py"),
-    ("src/hio/hioing.py", "/home/pyodide/hio/hioing.py"),
-    ("src/hio/base/__init__.py", "/home/pyodide/hio/base/__init__.py"),
-    ("src/hio/base/basing.py", "/home/pyodide/hio/base/basing.py"),
-    ("src/hio/base/doing.py", "/home/pyodide/hio/base/doing.py"),
-    ("src/hio/base/during.py", "/home/pyodide/hio/base/during.py"),
-    ("src/hio/base/filing.py", "/home/pyodide/hio/base/filing.py"),
-    ("src/hio/base/tyming.py", "/home/pyodide/hio/base/tyming.py"),
-    ("src/hio/base/webduring.py", "/home/pyodide/hio/base/webduring.py"),
-    ("src/hio/help/__init__.py", "/home/pyodide/hio/help/__init__.py"),
-    ("src/hio/help/decking.py", "/home/pyodide/hio/help/decking.py"),
-    ("src/hio/help/doming.py", "/home/pyodide/hio/help/doming.py"),
-    ("src/hio/help/helping.py", "/home/pyodide/hio/help/helping.py"),
-    ("src/hio/help/hicting.py", "/home/pyodide/hio/help/hicting.py"),
-    ("src/hio/help/mining.py", "/home/pyodide/hio/help/mining.py"),
-    ("src/hio/help/naming.py", "/home/pyodide/hio/help/naming.py"),
-    ("src/hio/help/ogling.py", "/home/pyodide/hio/help/ogling.py"),
-    ("src/hio/help/timing.py", "/home/pyodide/hio/help/timing.py"),
-]
+HIO_WHEELS = sorted(Path("dist").glob("hio-*.whl"))
+if not HIO_WHEELS:
+    raise RuntimeError("Build the HIO wheel into dist before running WASM tests.")
+HIO_WHEEL = HIO_WHEELS[-1]
 
 
-@copy_files_to_pyodide(file_list=HIO_FILES)
+@copy_files_to_pyodide(
+    file_list=[(HIO_WHEEL, f"/home/pyodide/{HIO_WHEEL.name}")],
+    install_wheels=False,
+)
 @run_in_pyodide(packages=WASM_PACKAGES)
 async def test_webduror_wasm_contract(selenium):
     """Verify WebDuror imports and core storage behavior in WASM."""
     import sys
+    from pathlib import Path
+
     import micropip
 
     await micropip.install(["cbor2==5.9.0", "ordered_set"])
-    sys.path.insert(0, "/home/pyodide")
+    hio_wheel = next(Path("/home/pyodide").glob("hio-*.whl"))
+    await micropip.install(str(hio_wheel), deps=False)
 
     import hio
     import hio.base


### PR DESCRIPTION
- added wasm ci for test_webduring_wasm.py that runs chrome, Firefox, and node
- made boxing.py, canning.py, and holding.py wasm import safe
- changed hio/base/\_\_init\_\_.py to make the imports wasm safe
  - use lazy importing so that modules are only loaded when they are directly called to avoid lmdb imported when running in wasm
- webduring.py ducktyped after during.py and modeled after the wasm compatible modules (webdber, webbaser) in keripy
- tests
- sortedcontainers package to setup.py for the wasm storage module 