### PR TITLE
cleaning imports and making subering wasm safe

### DIFF
--- a/src/hio/base/__init__.py
+++ b/src/hio/base/__init__.py
@@ -3,85 +3,17 @@
 hio.base Package
 """
 
-import importlib
+import sys
+
+IS_PYODIDE = "emscripten" in sys.platform
 
 from .tyming import Tymist, Tymee, Tymer
 from .doing import Doist, doize, doify, Doer, DoDoer
 from .filing import openFiler, Filer, FilerDoer
 from .webduring import WebSubDb, WebDuror, openWebDuror
+from .subering import (Duror, SuberBase, Suber, IoSuber, IoSetSuber,
+                       DomSuberBase, DomSuber, DomIoSuber, DomIoSetSuber, Subery)
 
-__all__ = (
-    "Tymist",
-    "Tymee",
-    "Tymer",
-    "Doist",
-    "doize",
-    "doify",
-    "Doer",
-    "DoDoer",
-    "openFiler",
-    "Filer",
-    "FilerDoer",
-    "WebSubDb",
-    "WebDuror",
-    "openWebDuror",
-    "Duror",
-    "openDuror",
-    "SuberBase",
-    "Suber",
-    "IoSuber",
-    "IoSetSuber",
-    "DomSuberBase",
-    "DomSuber",
-    "DomIoSuber",
-    "DomIoSetSuber",
-    "Subery",
-    "Bosser",
-    "Crewer",
-    "TagDex",
-)
-
-
-_DURING_EXPORTS = (
-    "Duror",
-    "openDuror",
-    "SuberBase",
-    "Suber",
-    "IoSuber",
-    "IoSetSuber",
-    "DomSuberBase",
-    "DomSuber",
-    "DomIoSuber",
-    "DomIoSetSuber",
-    "Subery",
-)
-
-_MULTIDOING_EXPORTS = (
-    "Bosser",
-    "Crewer",
-    "TagDex",
-)
-
-# When during or multidoing is imported, import it at runtime so lmdb is not
-# loaded when running in wasm. This imports the module/function, caches it,
-# and returns it.
-def __getattr__(name):
-    if name == "during" or name in _DURING_EXPORTS:
-        module = importlib.import_module(".during", __name__)
-        globals()["during"] = module
-        if name == "during":
-            return module
-        value = getattr(module, name)
-        globals()[name] = value
-        return value
-
-    if name == "multidoing" or name in _MULTIDOING_EXPORTS:
-        module = importlib.import_module(".multidoing", __name__)
-        globals()["multidoing"] = module
-        if name == "multidoing":
-            return module
-        value = getattr(module, name)
-        globals()[name] = value
-        return value
-
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+if not IS_PYODIDE:
+    from .during import openDuror
+    from .multidoing import Bosser, Crewer, TagDex

--- a/src/hio/base/hier/canning.py
+++ b/src/hio/base/hier/canning.py
@@ -7,14 +7,12 @@ Provides durable dom support for items in Hold
 from __future__ import annotations  # so type hints of classes get resolved later
 
 from collections.abc import Mapping
-from typing import Any, Type, ClassVar, TYPE_CHECKING
+from typing import Any, Type, ClassVar
 from dataclasses import dataclass, astuple, asdict, field, fields, InitVar
 
 from ...help import NonStringIterable, namify, registerify, TymeDom
 from ...hioing import HierError
-
-if TYPE_CHECKING:
-    from ..during import DomSuber
+from ..subering import DomSuber
 
 
 @namify

--- a/src/hio/base/subering.py
+++ b/src/hio/base/subering.py
@@ -1023,7 +1023,6 @@ class Subery(Duror):
     """Subery subclass of Duror for managing subdbs of Duror for durable storage
     of action data
     """
-    SubDbNames = ("cans.", "drqs.", "dsqs.")
 
     def __init__(self, **kwa):
         """
@@ -1047,7 +1046,7 @@ class Subery(Duror):
 
             """
             kwa.pop("stores", None)
-            await super(Subery, self).reopen(stores=self.SubDbNames, **kwa)
+            await super(Subery, self).reopen(stores=("cans.", "drqs.", "dsqs."), **kwa)
             self.cans = DomSuber(db=self, subkey='cans.')
             self.drqs = DomIoSuber(db=self, subkey="drqs.")  # durable queue
             self.dsqs = DomIoSetSuber(db=self, subkey="dsqs.")  # durable set queue

--- a/src/hio/base/subering.py
+++ b/src/hio/base/subering.py
@@ -5,8 +5,7 @@ Support for Durable storage abstracted subclasses  (lmdb or wasm pyodide Indexed
 """
 
 import sys
-
-from ordered_set import OrderedSet as oset
+from collections.abc import Iterable
 
 from hio import HierError
 from ..help import isNonStringIterable, RegDom, IceRegDom
@@ -30,7 +29,7 @@ class SuberBase():
         Sep (str): default separator to convert keys iterator to key bytes for db key
 
     Attributes:
-        db (dbing.LMDBer): base LMDB db
+        db (Duror): base LMDB db
         sdb (lmdb._Database): instance of lmdb named sub db for this Suber
         sep (str): separator for combining keys tuple of strs into key bytes
         verify (bool): True means reverify when ._des from db when applicable
@@ -45,7 +44,7 @@ class SuberBase():
                        verify: bool=False,
                        **kwa):
         """Parameters:
-            db (dbing.LMDBer): base db
+            db (Duror): base db
             subkey (str):  LMDB sub database key
             dupsort (bool): True means enable duplicates at each key
                                False (default) means do not enable duplicates at
@@ -267,7 +266,7 @@ class Suber(SuberBase):
                        dupsort: bool=False, **kwa):
         """
         Inherited Parameters:
-            db (dbing.LMDBer): base db
+            db (Duror): base db
             subkey (str):  LMDB sub database key
             dupsort (bool): True means enable duplicates at each key
                                False (default) means do not enable duplicates at
@@ -278,7 +277,7 @@ class Suber(SuberBase):
                            False means do not reverify. Default False
 
         Parameters:
-            db (dbing.LMDBer): base db
+            db (Duror): base db
             subkey (str):  LMDB sub database key
         """
         super(Suber, self).__init__(db=db, subkey=subkey, dupsort=False, **kwa)
@@ -367,14 +366,14 @@ class IoSuber(SuberBase):
     """
     IonSep = '.'  # separator for suffixing insertion order ordinal number
 
-    def __init__(self, db: dbing.LMDBer, *,
+    def __init__(self, db: Duror, *,
                        subkey: str='docs.',
                        dupsort: bool=False,
                        ionsep: str=None, **kwa):
         """Initialize instance
 
         Inherited Parameters:
-            db (dbing.LMDBer): base db
+            db (Duror): base db
             subkey (str):  LMDB sub database key
             dupsort (bool): True means enable duplicates at each key
                                False (default) means do not enable duplicates at
@@ -617,14 +616,14 @@ class IoSetSuber(SuberBase):
     """
     IonSep = '.'  # separator for suffixing insertion order ordinal number
 
-    def __init__(self, db: dbing.LMDBer, *,
+    def __init__(self, db: Duror, *,
                        subkey: str='docs.',
                        dupsort: bool=False,
                        ionsep: str=None, **kwa):
         """Initialize instance
 
         Inherited Parameters:
-            db (dbing.LMDBer): base db
+            db (Duror): base db
             subkey (str):  LMDB sub database key
             dupsort (bool): True means enable duplicates at each key
                                False (default) means do not enable duplicates at
@@ -1024,6 +1023,8 @@ class Subery(Duror):
     """Subery subclass of Duror for managing subdbs of Duror for durable storage
     of action data
     """
+    SubDbNames = ("cans.", "drqs.", "dsqs.")
+
     def __init__(self, **kwa):
         """
         Setup named sub databases.
@@ -1032,24 +1033,43 @@ class Subery(Duror):
         """
         super(Subery, self).__init__(**kwa)
 
+    if PYODIDE:
+        async def reopen(self, **kwa):
+            """Open sub databases
 
-    def reopen(self, **kwa):
-        """Open sub databases
+            Attributes:
+                cans (Suber): subdb whose values are serialized Can instances
+                    Can is a durable Bag
+                drqs (IoSetSub): subdb whose values are serialized RegDom instances
+                    Interfaced via a Durq which is a durable queue (FIFO)
+                dsqs (IoSetSub): subdb whose values are serialized RegDom instances
+                    Interfaced via a Dusq which is  durable set queue (FIFO deduped)
 
-        Attributes:
-            cans (Suber): subdb whose values are serialized Can instances
-                Can is a durable Bag
-            drqs (IoSetSub): subdb whose values are serialized RegDom instances
-                Interfaced via a Durq which is a durable queue (FIFO)
-            dsqs (IoSetSub): subdb whose values are serialized RegDom instances
-                Interfaced via a Dusq which is  durable set queue (FIFO deduped)
+            """
+            kwa.pop("stores", None)
+            await super(Subery, self).reopen(stores=self.SubDbNames, **kwa)
+            self.cans = DomSuber(db=self, subkey='cans.')
+            self.drqs = DomIoSuber(db=self, subkey="drqs.")  # durable queue
+            self.dsqs = DomIoSetSuber(db=self, subkey="dsqs.")  # durable set queue
 
-        """
-        super(Subery, self).reopen(**kwa)
+            return self.env
 
-        self.cans = DomSuber(db=self, subkey='cans.')
-        self.drqs = DomIoSuber(db=self, subkey="drqs.")  # durable queue
-        self.dsqs = DomIoSetSuber(db=self, subkey="dsqs.")  # durable set queue
+    else:
+        def reopen(self, **kwa):
+            """Open sub databases
 
-        return self.env
+            Attributes:
+                cans (Suber): subdb whose values are serialized Can instances
+                    Can is a durable Bag
+                drqs (IoSetSub): subdb whose values are serialized RegDom instances
+                    Interfaced via a Durq which is a durable queue (FIFO)
+                dsqs (IoSetSub): subdb whose values are serialized RegDom instances
+                    Interfaced via a Dusq which is  durable set queue (FIFO deduped)
 
+            """
+            super(Subery, self).reopen(**kwa)
+            self.cans = DomSuber(db=self, subkey='cans.')
+            self.drqs = DomIoSuber(db=self, subkey="drqs.")  # durable queue
+            self.dsqs = DomIoSetSuber(db=self, subkey="dsqs.")  # durable set queue
+
+            return self.env


### PR DESCRIPTION
- cleaned imports back to original shape with IS_PYODIDE flag
- made subering not use lmdber and also made async web compatible reopen function