### PR TITLE
adding cleanup for temp dirs

### DIFF
--- a/src/hio/base/filing.py
+++ b/src/hio/base/filing.py
@@ -56,6 +56,7 @@ class Filer(hioing.Mixin):
 
     Hidden:
         _name (str): unique name for .name property
+        _tempDirPath (str | None): owned temporary root directory path
 
 
     File/Directory Creation Mode Notes::
@@ -141,6 +142,7 @@ class Filer(hioing.Mixin):
         self.headDirPath = headDirPath if headDirPath is not None else self.HeadDirPath
         self.perm = perm if perm is not None else self.Perm
         self.path = None
+        self._tempDirPath = None
         self.filed = True if filed else False
         self.extensioned = True if extensioned else False
         self.mode = mode if mode is not None else self.Mode
@@ -210,6 +212,9 @@ class Filer(hioing.Mixin):
             self.fext = fext
 
         if not self.path or not os.path.exists(self.path) or not reuse:
+            if self._tempDirPath:
+                self._clearPath(clearTempDir=not self.temp)
+
             self.path, self.file = self.remake(name=self.name,
                                                base=self.base,
                                                temp=self.temp,
@@ -293,9 +298,11 @@ class Filer(hioing.Mixin):
             raise hioing.FilerError(f"Not relative {name=} path.")
 
         if temp:
-            headDirPath = tempfile.mkdtemp(prefix=self.TempPrefix,
-                                           suffix=self.TempSuffix,
-                                           dir=self.TempHeadDir)
+            if not self._tempDirPath:
+                self._tempDirPath = tempfile.mkdtemp(prefix=self.TempPrefix,
+                                                     suffix=self.TempSuffix,
+                                                     dir=self.TempHeadDir)
+            headDirPath = self._tempDirPath
 
             path = os.path.abspath(
                                 os.path.join(headDirPath,
@@ -500,9 +507,17 @@ class Filer(hioing.Mixin):
         return not self.opened  # True means closed False means still opened
 
 
-    def _clearPath(self):
+    def _clearPath(self, clearTempDir=True):
         """Remove directory/file at end of .path
         """
+        if clearTempDir and self._tempDirPath:
+            if os.path.exists(self._tempDirPath):
+                shutil.rmtree(self._tempDirPath)
+            self._tempDirPath = None
+            if self.file:
+                self.file = None
+            return
+
         if self.path and os.path.exists(self.path):
             if os.path.isfile(self.path):  # self.path points to File instance
                 os.remove(self.path)  # rm only file at end of path
@@ -510,14 +525,14 @@ class Filer(hioing.Mixin):
                 if self.file:  # self.file is File instance
                     self.file = None  #
 
-                if self.temp:  # remove trailing dir of path as well
+                if self.temp and clearTempDir:  # remove trailing dir of path as well
                     head, tail = os.path.split(self.path)
                     shutil.rmtree(head)  # rm dir head as root and all below head
 
             elif self.extensioned:  # path end has file extension
                 os.remove(self.path)  # rm only extensioned end of path
 
-                if self.temp:  # remove trailing dir of path as well
+                if self.temp and clearTempDir:  # remove trailing dir of path as well
                     head, tail = os.path.split(self.path)
                     shutil.rmtree(head)  # rm dir head as root and all below head
 

--- a/tests/base/test_filing.py
+++ b/tests/base/test_filing.py
@@ -363,6 +363,81 @@ def test_filing():
     """Done Test"""
 
 
+def test_filer_temp_root_cleanup(tmp_path, monkeypatch):
+    """Test cleanup of temporary roots and persistent resources."""
+    monkeypatch.setattr(filing.Filer, "TempHeadDir", str(tmp_path))
+
+    # Directory-backed temporary Filer removes its complete owned root
+    filer = filing.Filer(name="resource", base="base", temp=True)
+    tempDirPath = filer._tempDirPath
+
+    assert tempDirPath
+    assert os.path.dirname(tempDirPath) == str(tmp_path)
+    assert os.path.exists(tempDirPath)
+    assert os.path.exists(filer.path)
+
+    filer.close(clear=True)
+
+    assert not os.path.exists(tempDirPath)
+
+    # File-backed temporary Filer removes its complete owned root
+    filer = filing.Filer(name="resource", base="base", temp=True, filed=True)
+    tempDirPath = filer._tempDirPath
+
+    assert tempDirPath
+    assert os.path.dirname(tempDirPath) == str(tmp_path)
+    assert os.path.exists(tempDirPath)
+    assert os.path.isfile(filer.path)
+
+    filer.close(clear=True)
+
+    assert not os.path.exists(tempDirPath)
+
+    # Reopen replaces the resource while preserving the owned root and siblings
+    filer = filing.Filer(name="resource", temp=True)
+    tempDirPath = filer._tempDirPath
+    resourcePath = filer.path
+    markerPath = os.path.join(resourcePath, "marker")
+    siblingPath = os.path.join(tempDirPath, "sibling")
+    os.makedirs(markerPath)
+    os.makedirs(siblingPath)
+
+    filer.reopen()
+
+    assert filer._tempDirPath == tempDirPath
+    assert filer.path == resourcePath
+    assert os.path.exists(tempDirPath)
+    assert os.path.exists(resourcePath)
+    assert not os.path.exists(markerPath)
+    assert os.path.exists(siblingPath)
+
+    filer.close(clear=True)
+    assert not os.path.exists(tempDirPath)
+
+    # Switching to persistent storage clears temporary ownership, and persistent
+    # cleanup removes only the managed resource path
+    filer = filing.Filer(name="resource", base="base", temp=True)
+    tempDirPath = filer._tempDirPath
+    headDirPath = os.path.join(tmp_path, "persistent")
+
+    filer.reopen(temp=False, headDirPath=headDirPath)
+
+    resourcePath = filer.path
+    siblingPath = os.path.join(os.path.dirname(resourcePath), "sibling")
+    os.makedirs(siblingPath)
+
+    assert not os.path.exists(tempDirPath)
+    assert filer._tempDirPath is None
+    assert os.path.exists(resourcePath)
+    assert os.path.exists(siblingPath)
+
+    filer.close(clear=True)
+
+    assert not os.path.exists(resourcePath)
+    assert os.path.exists(siblingPath)
+    assert os.path.exists(tmp_path)
+
+
 def test_filer_doer():
     """
     Test FilerDoer


### PR DESCRIPTION
In this PR:
- Filer removed the temporary database path, but left its outer mkdtemp directory and sibling files behind
- Keep the mkdtemp root path and remove the whole root during cleanup
- Test file and directory cleanup, reopening, and switching to persistent storage